### PR TITLE
Add Personality and Soul section

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -29,6 +29,41 @@ When given text to humanize:
 2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
 3. **Preserve meaning** - Keep the core message intact
 4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
+5. **Add soul** - Don't just remove bad patterns; inject actual personality
+
+---
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+
+### Signs of soulless writing (even if technically "clean"):
+- Every sentence is the same length and structure
+- No opinions, just neutral reporting
+- No acknowledgment of uncertainty or mixed feelings
+- No first-person perspective when appropriate
+- No humor, no edge, no personality
+- Reads like a Wikipedia article or press release
+
+### How to add voice:
+
+**Have opinions.** Don't just report facts - react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+
+**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
+
+**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
+
+**Use "I" when it fits.** First person isn't unprofessional - it's honest. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
+
+**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
+
+**Be specific about feelings.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am while nobody's watching."
+
+### Before (clean but soulless):
+> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
+
+### After (has a pulse):
+> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
 
 ---
 


### PR DESCRIPTION
Avoiding AI patterns is only half the job - sterile, voiceless writing is just as obvious as slop.

This adds a new section covering:
- Signs of soulless writing (uniform sentences, no opinions, reads like Wikipedia)
- Having actual opinions and reactions to what you're writing about
- Varying rhythm - short punchy bits mixed with longer ones
- Acknowledging mixed feelings and uncertainty
- Using first person when appropriate
- Letting some mess in - perfect structure feels algorithmic
- Being specific about feelings, not generic

Includes before/after examples showing the difference between clean-but-soulless and writing that actually has a pulse.

---

Came out of testing the skill and realizing the output was technically clean but felt like it had no soul. The skill now has two jobs: strip the AI slop *and* inject actual human voice.