### PR TITLE
Fix YAML description: replace 'excessive conjunctive phrases' with 'f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Based on [Wikipedia's "Signs of AI writing"](https://en.wikipedia.org/wiki/Wikip
 
 ## Version History
 
+- **2.1.2** - Fixed YAML description to use "filler phrases" instead of misleading "excessive conjunctive phrases"
 - **2.1.1** - Fixed pattern #18 example (curly quotes vs straight quotes)
 - **2.1.0** - Added before/after examples for all 24 patterns
 - **2.0.0** - Complete rewrite based on raw Wikipedia article content

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: humanizer
-version: 2.1.1
+version: 2.1.2
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
   comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
   inflated symbolism, promotional language, superficial -ing analyses, vague
   attributions, em dash overuse, rule of three, AI vocabulary words, negative
-  parallelisms, and excessive conjunctive phrases.
+  parallelisms, and filler phrases.
 allowed-tools:
   - Read
   - Write


### PR DESCRIPTION
…iller phrases'

The YAML description mentioned 'excessive conjunctive phrases' as a pattern type, but this isn't one of the 24 documented patterns. The related concepts are actually covered under Pattern 7 (AI Vocabulary - includes 'Additionally') and Pattern 22 (Filler Phrases). Updated to use the more accurate term 'filler phrases' to match the actual pattern naming.

Bumped version from 2.1.1 to 2.1.2.