### PR TITLE
Update WARP.md with straight quotes instead of curly quotes

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -5,7 +5,7 @@ This file provides guidance to WARP (warp.dev) when working with code in this re
 ## What this repo is
 This repository is a **Claude Code skill** implemented entirely as Markdown.
 
-The “runtime” artifact is `SKILL.md`: Claude Code reads the YAML frontmatter (metadata + allowed tools) and the prompt/instructions that follow.
+The "runtime" artifact is `SKILL.md`: Claude Code reads the YAML frontmatter (metadata + allowed tools) and the prompt/instructions that follow.
 
 `README.md` is for humans: installation, usage, and a compact overview of the patterns.
 
@@ -16,7 +16,7 @@ The “runtime” artifact is `SKILL.md`: Claude Code reads the YAML frontmatter
   - After the frontmatter is the editor prompt: the canonical, detailed pattern list with examples.
 - `README.md`
   - Installation and usage instructions.
-  - Contains a summarized “24 patterns” table and a short version history.
+  - Contains a summarized "24 patterns" table and a short version history.
 
 When changing behavior/content, treat `SKILL.md` as the source of truth, and update `README.md` to stay consistent.
 
@@ -34,14 +34,14 @@ mkdir -p ~/.claude/skills/humanizer
 cp SKILL.md ~/.claude/skills/humanizer/
 ```
 
-## How to “run” it (Claude Code)
+## How to "run" it (Claude Code)
 Invoke the skill:
 - `/humanizer` then paste text
 
 ## Making changes safely
 ### Versioning (keep in sync)
 - `SKILL.md` has a `version:` field in its YAML frontmatter.
-- `README.md` has a “Version History” section.
+- `README.md` has a "Version History" section.
 
 If you bump the version, update both.
 


### PR DESCRIPTION
Replaced curly quotes with straight quotes.

If the skill claims curly quotes are a sign of ChatGPT, it should use straight quotes everywhere but the curly quote example.