### PR TITLE
feat: add OpenCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,46 @@
 # Humanizer
 
-A Claude Code skill that removes signs of AI-generated writing from text, making it sound more natural and human.
+A skill for Claude Code and OpenCode that removes signs of AI-generated writing from text, making it sound more natural and human.
 
 ## Installation
 
-### Recommended (clone directly into Claude Code skills directory)
+### Claude Code
+
+Clone directly into Claude Code's skills directory:
 
 ```bash
 mkdir -p ~/.claude/skills
 git clone https://github.com/blader/humanizer.git ~/.claude/skills/humanizer
 ```
 
-### Manual install/update (only the skill file)
-
-If you already have this repo cloned (or you downloaded `SKILL.md`), copy the skill file into Claude Code’s skills directory:
+Or copy the skill file manually if you already have this repo cloned:
 
 ```bash
 mkdir -p ~/.claude/skills/humanizer
 cp SKILL.md ~/.claude/skills/humanizer/
 ```
 
+### OpenCode
+
+Clone directly into OpenCode's skills directory:
+
+```bash
+mkdir -p ~/.config/opencode/skills
+git clone https://github.com/blader/humanizer.git ~/.config/opencode/skills/humanizer
+```
+
+Or copy the skill file manually if you already have this repo cloned:
+
+```bash
+mkdir -p ~/.config/opencode/skills/humanizer
+cp SKILL.md ~/.config/opencode/skills/humanizer/
+```
+
+> **Note:** OpenCode also scans `~/.claude/skills/` for compatibility, so a single clone into `~/.claude/skills/humanizer/` works for both tools.
+
 ## Usage
 
-In Claude Code, invoke the skill:
+### Claude Code
 
 ```
 /humanizer
@@ -30,7 +48,15 @@ In Claude Code, invoke the skill:
 [paste your text here]
 ```
 
-Or ask Claude to humanize text directly:
+### OpenCode
+
+```
+/humanizer
+
+[paste your text here]
+```
+
+Or ask the model to humanize text directly in either tool:
 
 ```
 Please humanize this text: [your text]

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,6 +8,8 @@ description: |
   inflated symbolism, promotional language, superficial -ing analyses, vague
   attributions, em dash overuse, rule of three, AI vocabulary words, negative
   parallelisms, and excessive conjunctive phrases.
+license: MIT
+compatibility: claude-code opencode
 allowed-tools:
   - Read
   - Write


### PR DESCRIPTION
## Summary

This PR makes the skill work with both **Claude Code** and **OpenCode**.

### What changed

**SKILL.md** - two new frontmatter fields:
- license: MIT - OpenCode surfaces this in skill listings
- compatibility: claude-code opencode - explicitly declares which tools this skill targets

The existing fields (version, allowed-tools) are Claude Code-specific and are silently ignored by OpenCode, so there is no breakage.

**README.md** - reorganized Installation and Usage sections:
- Split into Claude Code and OpenCode subsections, each with clone and manual-copy commands
- Added a note that a single clone into ~/.claude/skills/ covers both tools, since OpenCode scans that path for compatibility
- Removed the duplicate Manual install/update section left over from the original structure

### Why this works without forking the skill file

OpenCode skill discovery scans multiple locations, including ~/.claude/skills/ as a Claude-compatible path. So users who already have the skill installed for Claude Code get OpenCode support for free. The native OpenCode path (~/.config/opencode/skills/) is also documented for users who only use OpenCode.

The SKILL.md body is loaded identically by both tools as the agent system prompt when /humanizer is invoked.

### Install paths

| Tool | Path |
|------|------|
| Claude Code | ~/.claude/skills/humanizer/SKILL.md |
| OpenCode (native) | ~/.config/opencode/skills/humanizer/SKILL.md |
| Both (single clone) | ~/.claude/skills/humanizer/SKILL.md |