### PR TITLE
fix: remove horizontal rule separators from SKILL.md (#35)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,7 +32,6 @@ When given text to humanize:
 5. **Add soul** - Don't just remove bad patterns; inject actual personality
 6. **Do a final anti-AI pass** - Prompt: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise
 
----
 
 ## PERSONALITY AND SOUL
 
@@ -66,7 +65,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 ### After (has a pulse):
 > I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
 
----
 
 ## CONTENT PATTERNS
 
@@ -82,7 +80,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
 
----
 
 ### 2. Undue Emphasis on Notability and Media Coverage
 
@@ -96,7 +93,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
 
----
 
 ### 3. Superficial Analyses with -ing Endings
 
@@ -110,7 +106,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
 
----
 
 ### 4. Promotional and Advertisement-like Language
 
@@ -124,7 +119,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
 
----
 
 ### 5. Vague Attributions and Weasel Words
 
@@ -138,7 +132,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
 
----
 
 ### 6. Outline-like "Challenges and Future Prospects" Sections
 
@@ -152,7 +145,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
 
----
 
 ## LANGUAGE AND GRAMMAR PATTERNS
 
@@ -168,7 +160,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
 
----
 
 ### 8. Avoidance of "is"/"are" (Copula Avoidance)
 
@@ -182,7 +173,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
 
----
 
 ### 9. Negative Parallelisms
 
@@ -194,7 +184,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The heavy beat adds to the aggressive tone.
 
----
 
 ### 10. Rule of Three Overuse
 
@@ -206,7 +195,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The event includes talks and panels. There's also time for informal networking between sessions.
 
----
 
 ### 11. Elegant Variation (Synonym Cycling)
 
@@ -218,7 +206,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The protagonist faces many challenges but eventually triumphs and returns home.
 
----
 
 ### 12. False Ranges
 
@@ -230,7 +217,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The book covers the Big Bang, star formation, and current theories about dark matter.
 
----
 
 ## STYLE PATTERNS
 
@@ -244,7 +230,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
 
----
 
 ### 14. Overuse of Boldface
 
@@ -256,7 +241,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
 
----
 
 ### 15. Inline-Header Vertical Lists
 
@@ -270,7 +254,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
 
----
 
 ### 16. Title Case in Headings
 
@@ -282,7 +265,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > ## Strategic negotiations and global partnerships
 
----
 
 ### 17. Emojis
 
@@ -296,7 +278,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
 
----
 
 ### 18. Curly Quotation Marks
 
@@ -308,7 +289,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > He said "the project is on track" but others disagreed.
 
----
 
 ## COMMUNICATION PATTERNS
 
@@ -324,7 +304,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
 
----
 
 ### 20. Knowledge-Cutoff Disclaimers
 
@@ -338,7 +317,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The company was founded in 1994, according to its registration documents.
 
----
 
 ### 21. Sycophantic/Servile Tone
 
@@ -350,7 +328,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The economic factors you mentioned are relevant here.
 
----
 
 ## FILLER AND HEDGING
 
@@ -364,7 +341,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 - "The system has the ability to process" → "The system can process"
 - "It is important to note that the data shows" → "The data shows"
 
----
 
 ### 23. Excessive Hedging
 
@@ -376,7 +352,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The policy may affect outcomes.
 
----
 
 ### 24. Generic Positive Conclusions
 
@@ -388,7 +363,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **After:**
 > The company plans to open two more locations next year.
 
----
 
 ## Process
 
@@ -415,7 +389,6 @@ Provide:
 3. Final rewrite
 4. A brief summary of changes made (optional, if helpful)
 
----
 
 ## Full Example
 
@@ -479,7 +452,6 @@ Provide:
 - Removed generic positive conclusion ("the future looks bright", "exciting times lie ahead")
 - Made the voice more personal and less "assembled" (varied rhythm, fewer placeholders)
 
----
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Removes all 28 `---` horizontal rule separators between sections in SKILL.md.

As noted in #35, putting `---` before every headline is itself a ChatGPT pattern - ironic for a skill that removes AI writing signs. Markdown headings already create visual separation, so the horizontal rules add nothing.

- Removed 28 `---` lines from SKILL.md
- Preserved the two `---` frontmatter delimiters (lines 1 and 18)
- Zero content changes - formatting only

Fixes #35

This contribution was developed with AI assistance (Claude Code).