### PR TITLE
docs: add Community Forks section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 >
 > The only real backstop is tests. Without them, you're mostly judging vibes.
 
+## Community Forks
+
+| Language | Repository | Patterns | Maintainer |
+|----------|-----------|----------|------------|
+| Deutsch | [marmbiz/humanizer-de](https://github.com/marmbiz/humanizer-de) | 34 | Martin Moeller |
+
 ## References
 
 - [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) - Primary source


### PR DESCRIPTION
## Summary

- Adds a "Community Forks" table to the README linking to independently maintained language editions
- First entry: [marmbiz/humanizer-de](https://github.com/marmbiz/humanizer-de) (German, 34 patterns)

The German fork has been tracking upstream since v2.2.0 and extends the original 24 patterns to 34 German-specific ones, based on the [German Wikipedia article on AI writing signs](https://de.wikipedia.org/wiki/Wikipedia:Anzeichen_f%C3%BCr_KI-generierte_Inhalte).

The table format makes it easy for future community forks in other languages to add themselves.