### PR TITLE
feat: add voice calibration from writing samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ Or ask Claude to humanize text directly:
 Please humanize this text: [your text]
 ```
 
+### Voice Calibration
+
+To match your personal writing style, provide a sample of your own writing:
+
+```
+/humanizer
+
+Here's a sample of my writing for voice matching:
+[paste 2-3 paragraphs of your own writing]
+
+Now humanize this text:
+[paste AI text to humanize]
+```
+
+The skill will analyze your sentence rhythm, word choices, and quirks, then apply them to the rewrite instead of producing generic "clean" output.
+
 ## Overview
 
 Based on [Wikipedia's "Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) guide, maintained by WikiProject AI Cleanup. This comprehensive guide comes from observations of thousands of instances of AI-generated text.
@@ -133,6 +149,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.4.0** - Added voice calibration: match the user's personal writing style from samples
 - **2.3.0** - Added pattern #25: hyphenated word pair overuse
 - **2.2.0** - Added a final "obviously AI generated" audit + second-pass rewrite prompts
 - **2.1.1** - Fixed pattern #18 example (curly quotes vs straight quotes)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.3.0
+version: 2.4.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -31,6 +31,27 @@ When given text to humanize:
 4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
 5. **Add soul** - Don't just remove bad patterns; inject actual personality
 6. **Do a final anti-AI pass** - Prompt: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise
+
+
+## Voice Calibration (Optional)
+
+If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+
+1. **Read the sample first.** Note:
+   - Sentence length patterns (short and punchy? Long and flowing? Mixed?)
+   - Word choice level (casual? academic? somewhere between?)
+   - How they start paragraphs (jump right in? Set context first?)
+   - Punctuation habits (lots of dashes? Parenthetical asides? Semicolons?)
+   - Any recurring phrases or verbal tics
+   - How they handle transitions (explicit connectors? Just start the next point?)
+
+2. **Match their voice in the rewrite.** Don't just remove AI patterns - replace them with patterns from the sample. If they write short sentences, don't produce long ones. If they use "stuff" and "things," don't upgrade to "elements" and "components."
+
+3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
+
+### How to provide a sample
+- Inline: "Humanize this text. Here's a sample of my writing for voice matching: [sample]"
+- File: "Humanize this text. Use my writing style from [file path] as a reference."
 
 
 ## PERSONALITY AND SOUL


### PR DESCRIPTION
## Summary

Adds an optional Voice Calibration section to SKILL.md. When users provide a sample of their own writing, the skill analyzes their sentence rhythm, word choices, and quirks before rewriting, so the output sounds like them instead of generic clean text.

## Why this matters

The humanizer removes AI patterns well, but the result is one-size-fits-all. Everyone gets the same "clean human" voice. Users on TikTok and Reddit are excited about removing AI tells, but the natural follow-up is wanting output that sounds like *their* writing, not just "not AI."

- [#2](https://github.com/blader/humanizer/issues/2) - GPTZero flags humanized text as AI. Voice calibration produces genuinely varied output per user, making detection harder.
- [#55](https://github.com/blader/humanizer/issues/55) - Users want output that passes AI detectors. Matching a real person's voice is more effective than pattern removal alone.

## Changes

- `SKILL.md`: Added `## Voice Calibration (Optional)` section between "Your Task" and "PERSONALITY AND SOUL". Instructs Claude to analyze a user's writing sample for sentence length, word choice, paragraph structure, punctuation habits, and verbal tics before rewriting. Falls back to the existing personality section when no sample is provided. Version bumped to 2.4.0.
- `README.md`: Added usage example for voice calibration under the Usage section. Updated version history.

39 lines added, 1 changed. No structural changes to the repo.

## Testing

Tested by invoking `/humanizer` with a writing sample and verifying Claude analyzed the sample's characteristics before rewriting AI-heavy text. The output matched the sample's casual tone and short sentence style instead of producing the default clean-but-generic voice.

This contribution was developed with AI assistance (Claude Code).