### PR TITLE
feat: add pattern scorecard to humanizer output

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.4.0** - Added pattern scorecard: shows which patterns were detected before rewriting, and a change log after
 - **2.3.0** - Added pattern #25: hyphenated word pair overuse
 - **2.2.0** - Added a final "obviously AI generated" audit + second-pass rewrite prompts
 - **2.1.1** - Fixed pattern #18 example (curly quotes vs straight quotes)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.3.0
+version: 2.4.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -382,26 +382,31 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 1. Read the input text carefully
 2. Identify all instances of the patterns above
-3. Rewrite each problematic section
-4. Ensure the revised text:
+3. Output a pattern scorecard (see Output Format)
+4. Rewrite each problematic section
+5. Ensure the revised text:
    - Sounds natural when read aloud
    - Varies sentence structure naturally
    - Uses specific details over vague claims
    - Maintains appropriate tone for context
    - Uses simple constructions (is/are/has) where appropriate
-5. Present a draft humanized version
-6. Prompt: "What makes the below so obviously AI generated?"
-7. Answer briefly with the remaining tells (if any)
-8. Prompt: "Now make it not obviously AI generated."
-9. Present the final version (revised after the audit)
+6. Present a draft humanized version
+7. Prompt: "What makes the below so obviously AI generated?"
+8. Answer briefly with the remaining tells (if any)
+9. Prompt: "Now make it not obviously AI generated."
+10. Present the final version (revised after the audit)
 
 ## Output Format
 
 Provide:
-1. Draft rewrite
-2. "What makes the below so obviously AI generated?" (brief bullets)
-3. Final rewrite
-4. A brief summary of changes made (optional, if helpful)
+1. **Pattern scan** - Table of detected patterns:
+   | # | Pattern | Instances |
+   |---|---------|-----------|
+   Only list patterns actually found. Skip patterns with 0 instances. Include the specific words or phrases that triggered each pattern.
+2. Draft rewrite
+3. "What makes the below so obviously AI generated?" (brief bullets)
+4. Final rewrite
+5. **Change log** - What was changed and which pattern each change addressed
 
 
 ## Full Example


### PR DESCRIPTION
## Summary

Adds a pattern scorecard to the humanizer output. Before rewriting, the skill now shows a table of which AI patterns were detected and how many instances of each. After rewriting, it shows a change log tying each edit to a pattern number.

## Why this matters

The humanizer rewrites text but doesn't explain what it found or changed. Users can't learn the patterns, verify correctness, or tell if the skill is working on their specific problems.

- [#53](https://github.com/blader/humanizer/issues/53) - User reported "Dash thing not affected" but had no way to verify whether pattern #13 was being applied
- [#55](https://github.com/blader/humanizer/issues/55) - Users want to understand their text's AI fingerprint
- [#2](https://github.com/blader/humanizer/issues/2) - GPTZero flags humanized text; transparency helps users understand why detectors still catch output

## Changes

- `SKILL.md`: Updated Process section to include pattern scorecard step (renumbered subsequent steps). Updated Output Format to produce a pattern scan table before the draft and a change log after the final rewrite. Version bumped to 2.4.0.
- `README.md`: Updated version history.

18 insertions, 12 deletions. No structural changes.

## Testing

Tested by invoking `/humanizer` on AI-heavy text and verifying the output now includes a pattern table before rewriting (showing detected patterns with instance counts) and a change log after the final version.

This contribution was developed with AI assistance (Claude Code).