### PR TITLE
Fix pattern count in WARP.md: 24 → 25

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -16,7 +16,7 @@ The “runtime” artifact is `SKILL.md`: Claude Code reads the YAML frontmatter
   - After the frontmatter is the editor prompt: the canonical, detailed pattern list with examples.
 - `README.md`
   - Installation and usage instructions.
-  - Contains a summarized “24 patterns” table and a short version history.
+  - Contains a summarized “25 patterns” table and a short version history.
 
 When changing behavior/content, treat `SKILL.md` as the source of truth, and update `README.md` to stay consistent.
 


### PR DESCRIPTION
## Summary

- WARP.md referenced "24 patterns" but pattern #25 (hyphenated word pair overuse) was added in v2.3.0
- The README heading already says "25 Patterns Detected" — this brings WARP.md in sync

## Change

One-line fix in `WARP.md:19`: `"24 patterns"` → `"25 patterns"`