### PR TITLE
fix: move version to metadata in SKILL.md frontmatter

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: humanizer
-version: 2.5.1
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -17,6 +16,8 @@ allowed-tools:
   - Grep
   - Glob
   - AskUserQuestion
+metadata:
+  version: 2.5.1
 ---
 
 # Humanizer: Remove AI Writing Patterns

--- a/WARP.md
+++ b/WARP.md
@@ -40,7 +40,7 @@ Invoke the skill:
 
 ## Making changes safely
 ### Versioning (keep in sync)
-- `SKILL.md` has a `version:` field in its YAML frontmatter.
+- `SKILL.md` has a `version:` field under `metadata:` in its YAML frontmatter.
 - `README.md` has a “Version History” section.
 
 If you bump the version, update both.


### PR DESCRIPTION
Claude Code's skill parser rejects `version` as a top-level frontmatter key. The allowed set is: `name`, `description`, `license`, `allowed-tools`, `compatibility`, `metadata`.

This moves `version: 2.5.1` under a `metadata:` block so the skill loads without the "unexpected key" error ([#41](https://github.com/blader/humanizer/issues/41), also reported in [#8](https://github.com/blader/humanizer/issues/8)).

Also updates WARP.md's versioning section to reflect the new location.

Fixes #41

This contribution was developed with AI assistance (Codex).