### PR TITLE
fix: add content preservation rule and strengthen em dash handling

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -30,9 +30,10 @@ When given text to humanize:
 1. **Identify AI patterns** - Scan for the patterns listed below
 2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
 3. **Preserve meaning** - Keep the core message intact
-4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
-5. **Add soul** - Don't just remove bad patterns; inject actual personality
-6. **Do a final anti-AI pass** - Prompt: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise
+4. **Never truncate** - Your output must cover everything the original covers. Rewrite sentences, don't delete them. If the original has five paragraphs, the rewrite has five paragraphs.
+5. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
+6. **Add soul** - Don't just remove bad patterns; inject actual personality
+7. **Do a final anti-AI pass** - Prompt: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise
 
 
 ## Voice Calibration (Optional)
@@ -269,6 +270,14 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 **After:**
 > The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+Also catch spaced em dashes (` — `) and double hyphens (` -- `) used as em dashes. These are the same pattern in different typography.
+
+**Before:**
+> The new policy — announced without warning — affects thousands of workers. The changes -- long overdue according to critics -- will take effect immediately.
+
+**After:**
+> The new policy, announced without warning, affects thousands of workers. The changes, long overdue according to critics, will take effect immediately.
 
 
 ### 15. Overuse of Boldface


### PR DESCRIPTION
Two users reported the humanizer truncating their text and missing dash variants (#78, #53). This adds a safeguard and broadens the em dash pattern.

## Changes

1. New step 4 in the "Your Task" checklist: "Never truncate." The output must cover everything the original covers. If the input has five paragraphs, the rewrite has five paragraphs.

2. Pattern 14 (Em Dash Overuse) now includes spaced em dashes (` — `) and double hyphens (` -- `), which LLMs produce just as often as the typographic em dash.

Fixes #78, relates to #53

This contribution was developed with AI assistance (Codex).