### PR TITLE
Add patterns 30-31, expand rules 9 and 14 (v2.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
-## 29 Patterns Detected (with Before/After Examples)
+## 31 Patterns Detected (with Before/After Examples)
 
 ### Content Patterns
 
@@ -107,7 +107,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 |---|---------|--------|-------|
 | 7 | **AI vocabulary** | "Actually... additionally... testament... landscape... showcasing" | "also... remain common" |
 | 8 | **Copula avoidance** | "serves as... features... boasts" | "is... has" |
-| 9 | **Negative parallelisms / tailing negations** | "It's not just X, it's Y", "..., no guessing" | State the point directly |
+| 9 | **Negative parallelisms / tailing negations / "rather than" dismissals** | "It's not just X, it's Y", "..., no guessing", "X rather than Y (where Y is unstated)" | State the point directly; cut dismissed alternatives nobody claimed |
 | 10 | **Rule of three** | "innovation, inspiration, and insights" | Use natural number of items |
 | 11 | **Synonym cycling** | "protagonist... main character... central figure... hero" | "protagonist" (repeat when clearest) |
 | 12 | **False ranges** | "from the Big Bang to dark matter" | List topics directly |
@@ -117,7 +117,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 | # | Pattern | Before | After |
 |---|---------|--------|-------|
-| 14 | **Em dash overuse** | "institutions—not the people—yet this continues—" | Prefer commas or periods |
+| 14 | **Em dash overuse / paired bracketing** | "institutions—not the people—yet this continues—", "report—covering three continents—concluded" | Prefer commas or periods; break paired brackets into separate sentences or appositives |
 | 15 | **Boldface overuse** | "**OKRs**, **KPIs**, **BMC**" | "OKRs, KPIs, BMC" |
 | 16 | **Inline-header lists** | "**Performance:** Performance improved" | Convert to prose |
 | 17 | **Title Case Headings** | "Strategic Negotiations And Partnerships" | "Strategic negotiations and partnerships" |
@@ -127,6 +127,8 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 27 | **Persuasive authority tropes** | "At its core, what matters is..." | State the point directly |
 | 28 | **Signposting announcements** | "Let's dive in", "Here's what you need to know" | Start with the content |
 | 29 | **Fragmented headers** | "## Performance" + "Speed matters." | Let the heading do the work |
+| 30 | **Conditional frame stacking** | "If the argument holds, and if the reading is right, then perhaps..." | State the conclusion; reserve "if" for real analytical branches |
+| 31 | **Miscalibrated epistemic confidence** | Over: "decisively demonstrates fundamentally"; Over-hedge: "appears to have arguably may have somewhat" | Narrow the claim to what the evidence supports; don't replace over-assertion with hedges |
 
 ### Communication Patterns
 
@@ -179,6 +181,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.6.0** - Added patterns 30 (conditional frame stacking) and 31 (miscalibrated epistemic confidence); expanded rule 9 to cover "rather than" dismissals; expanded rule 14 to cover paired em dash bracketing; raising the total to 31 patterns
 - **2.5.1** - Added a passive-voice / subjectless-fragment rule, raising the total to 29 patterns
 - **2.5.0** - Added patterns for persuasive framing, signposting, and fragmented headers; expanded negative parallelisms to cover tailing negations; tightened wording around em dash overuse; fixed frontmatter wording to use "filler phrases"
 - **2.4.0** - Added voice calibration: match the user's personal writing style from samples

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: humanizer
-version: 2.5.1
+version: 2.6.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
   comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
   inflated symbolism, promotional language, superficial -ing analyses, vague
   attributions, em dash overuse, rule of three, AI vocabulary words, passive
-  voice, negative parallelisms, and filler phrases.
+  voice, negative parallelisms, filler phrases, conditional frame stacking, and
+  miscalibrated epistemic confidence.
 license: MIT
 compatibility: claude-code opencode
 allowed-tools:
@@ -197,9 +198,9 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
 
 
-### 9. Negative Parallelisms and Tailing Negations
+### 9. Negative Parallelisms, Tailing Negations, and "Rather Than" Dismissals
 
-**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause. A third form of the same pattern is "rather than" used to stage a contrast by dismissing an alternative that nobody was claiming in the first place.
 
 **Before:**
 > It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
@@ -212,6 +213,14 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 **After:**
 > The options come from the selected item without forcing the user to guess.
+
+**Before ("rather than" dismissal):**
+> The goal is to write clearly rather than to impress the reader with complexity.
+
+**After:**
+> The goal is to write clearly.
+
+**Test:** Ask whether the discarded alternative (Y in "X rather than Y") is actually on the table. If no one was claiming Y, cut the dismissal and just say X.
 
 
 ### 10. Rule of Three Overuse
@@ -260,15 +269,28 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 ## STYLE PATTERNS
 
-### 14. Em Dash Overuse
+### 14. Em Dash Overuse and Paired Bracketing
 
 **Problem:** LLMs use em dashes (—) more than humans, mimicking "punchy" sales writing. In practice, most of these can be rewritten more cleanly with commas, periods, or parentheses.
+
+A specific sub-pattern is paired em dash bracketing: wrapping an elaboration between two dashes (X — elaboration — continues). This looks inserted rather than written — like something dropped into an existing sentence rather than composed as part of it.
 
 **Before:**
 > The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
 
 **After:**
 > The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+**Before (paired bracketing):**
+> The report—which covered three continents and twelve case studies—concluded that demand had shifted.
+
+**After options (depending on type of insertion):**
+- If a list: break into a separate sentence. "The report covered three continents and twelve case studies. It concluded that demand had shifted."
+- If an appositive: use a comma or recast. "The report, covering three continents and twelve case studies, concluded that demand had shifted."
+- If a parenthetical aside: use parentheses if truly aside, or restructure. "The report (three continents, twelve case studies) concluded that demand had shifted."
+- If subject expansion: rewrite as two sentences.
+
+**Exception:** A single, short, earned bracket that does not repeat elsewhere in the passage is fine. The problem is the pattern, not any one instance.
 
 
 ### 15. Overuse of Boldface
@@ -460,6 +482,43 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > ## Performance
 >
 > When users hit a slow page, they leave.
+
+
+### 30. Conditional Frame Stacking
+
+**Problem:** AI hedges its own conclusions by stacking multiple "if" clauses in the same passage — "if the argument holds," "if the reading is right," "if this interpretation is correct." One conditional at a genuine analytical branching point is fine. A cluster of them in a conclusion or summary signals the writer is not standing behind their own work.
+
+**Before:**
+> If the argument holds, and if the evidence supports this reading, then the policy may have had some effect — if, that is, the context was as described.
+
+**After:**
+> The evidence supports the argument that the policy had an effect in this context.
+
+**Fix:** In a conclusion or summary, state what the argument found. Reserve "if" for real analytical branches where the outcome genuinely differs depending on the condition — not as a repeated hedge against being wrong.
+
+
+### 31. Miscalibrated Epistemic Confidence
+
+**Problem:** A two-sided pattern. AI swings between over-asserting and over-hedging, sometimes in the same passage.
+
+- **Over-assertion:** Loading claims with words like "decisively," "fundamentally," "completely," "unquestionably," "clearly demonstrates" when the evidence is more limited.
+- **Over-hedging:** Layering qualifiers such as "appears to have arguably," "may have somewhat," "could potentially suggest" when the evidence actually supports a more direct statement.
+
+Both are tells. The fix is not to replace one extreme with the other — it is to narrow the claim to what the evidence actually supports.
+
+**Before (over-assertion):**
+> The data decisively demonstrates that remote work fundamentally transformed productivity across all sectors.
+
+**After:**
+> In the surveyed companies, productivity rose an average of 8% in the first year of remote work.
+
+**Before (over-hedging):**
+> It appears that the policy may have arguably had some effect on outcomes, potentially suggesting a modest shift.
+
+**After:**
+> The policy was associated with a modest improvement in outcomes in two of the three cases studied.
+
+**Critical rule:** Do not fix over-assertion by adding hedges. Fix it by narrowing the claim.
 
 ---
 


### PR DESCRIPTION
## What this adds

Four improvements derived from real editing work on academic prose:

### Expanded Rule 9 — "rather than" overuse
The existing rule covered "Not only…but" and tailing negations. Added "rather than" as a third form of the same pattern — AI stages a contrast by dismissing an alternative (Y) that nobody was claiming. Added a test: ask whether the discarded alternative is actually on the table. If not, just say X.

### Expanded Rule 14 — paired em dash bracketing
The existing rule covered general em dash overuse. Added the specific case of paired bracketing (X — elaboration — continues), which looks inserted rather than written. Includes four fix strategies keyed to the type of insertion (list, appositive, parenthetical, subject expansion) and an exception for short, earned, non-repeated brackets.

### New Rule 30 — Conditional frame stacking ("If X…" clusters)
AI hedges its own conclusions with multiple "if the argument holds… if the reading is right…" clauses in the same passage. One conditional at a genuine branching point is fine. A cluster of them in a conclusion signals the writer isn't standing behind their own work. Fix: state what the argument found; reserve "if" for real analytical branches.

### New Rule 31 — Miscalibrated epistemic confidence
A two-sided rule. AI swings between over-asserting (loading claims with "decisively," "fundamentally," "completely") and over-hedging ("appears to have arguably," "may have somewhat"). Both are tells. The fix is never to replace one extreme with the other — it is to narrow the claim to what the evidence actually supports. Includes a "critical rule": don't fix over-assertion by adding hedges.

## Version
2.5.1 → 2.6.0

## Pattern count
29 → 31