### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## [2.5.1] - 2026-04
+- Added passive voice detection patterns (#80)
+- Integrated remaining prompt updates coherently (#79)
+- Added OpenCode support (#47)
+- Fixed excessive "actually" usage pattern (#77)
+
+## [2.5.0] - 2026-03
+- Added voice calibration from writing samples
+- Fixed pattern count in WARP.md: 24 → 25
+
+## [2.1.0] - 2026-01
+- Added before/after examples for all 24 patterns
+
+## [2.0.0] - 2026-01
+- Complete rewrite based on Wikipedia's "Signs of AI writing" page
+- Restructured patterns into four categories: Content, Language, Style, Communication
+
+## [1.0.0] - 2026-01
+- Initial release


### PR DESCRIPTION
## What
Adds a `CHANGELOG.md` documenting version history from v1.0 through v2.5.1.

## Why
This repo has 13k stars and gets forked and vendored widely. Right now there's no way to know what changed between versions without reading through commits one by one.

A changelog helps in three ways:
- **Contributors** can understand prior decisions before adding new patterns
- **Users** know when an upgrade is worth pulling (e.g. passive voice was added in 2.5.1)
- **Forks/vendors** can track what they're diverging from

Built from the existing commit history. Happy to fill in any gaps if there are version details I missed.