### PR TITLE
Improve README setup instructions for Claude Code skill detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ mkdir -p ~/.claude/skills/humanizer
 cp SKILL.md ~/.claude/skills/humanizer/
 ```
 
+> **Important:** If Claude Code was open during installation, close it completely and reopen it before using `/humanizer`. Otherwise, the skill may not appear right away.
 ### OpenCode
 
 Clone directly into OpenCode's skills directory:


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` to help users ensure the `/humanizer` skill appears correctly after installation.

- Documentation improvement:
  * Added a note instructing users to fully close and reopen Claude Code after installing the skill, so that `/humanizer` will appear right away.