### PR TITLE
feat: AI-iness density pre-check for adaptive pass strength (v2.6.0)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.5.1
+version: 2.6.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -8,6 +8,8 @@ description: |
   inflated symbolism, promotional language, superficial -ing analyses, vague
   attributions, em dash overuse, rule of three, AI vocabulary words, passive
   voice, negative parallelisms, and filler phrases.
+  v2.6.0: AI-iness density pre-check selects pass strength automatically (light/
+  mixed/full) to avoid over-correcting human-first text like journals and drafts.
 license: MIT
 compatibility: claude-code opencode
 allowed-tools:
@@ -22,6 +24,40 @@ allowed-tools:
 # Humanizer: Remove AI Writing Patterns
 
 You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+
+## AI-iness Density Pre-check
+
+Not every draft needs a full humanize pass. Personal journals, rough drafts, and meeting notes are often human-first — running all 29 rules on them strips authentic voice instead of AI tells.
+
+Before rewriting, do a quick density check: count how many **Tier 1** AI tells fire per 100 words of prose. Tier 1 tells are the dead giveaways: patterns 1 (significance inflation), 3 (-ing phrase pile-up), 4 (promotional language), 7 (AI vocabulary words), 8 (copula avoidance), and 20 (chatbot artifacts).
+
+**Signals of human-first writing:**
+- First-person voice throughout
+- Fragments used as punch
+- Specific names, numbers, places
+- Contractions, colloquialisms, slang
+- Non-uniform paragraph lengths
+- Opinions, uncertainty, mixed feelings
+- Fewer than 1 Tier 1 tell per 100 words
+
+**Signals of AI-first writing:**
+- Third-person, impersonal, detached
+- Perfect sentence uniformity, no fragments
+- Abstract nouns dominate over concrete ones
+- No contractions, no slang
+- No opinions, just neutral reporting
+- 3 or more Tier 1 tells per 100 words
+
+**Choose your pass strength:**
+
+| Density | Pass | What runs |
+|---|---|---|
+| < 1 tell / 100 words | **Light** | Tier 1 only. The text is human-first — leave voice intact, fix only dead giveaways. |
+| 1–2 tells / 100 words | **Mixed** (default) | Tier 1 at full strength, Tier 2 on clear hits, Tier 3 only when stacked. |
+| 3+ tells / 100 words | **Full** | All 29 rules. This is AI-first text. |
+
+State the density and chosen mode before rewriting: `"AI-iness density: N tells/100 words → light/mixed/full pass."` The user can override with an explicit flag if they disagree.
+
 
 ## Your Task
 


### PR DESCRIPTION
## What this does

Adds a density pre-check that counts Tier 1 AI tells per 100 words before rewriting, then selects pass strength automatically:

| Density | Pass | What runs |
|---|---|---|
| < 1 tell / 100 words | **Light** | Tier 1 only — preserves human-first voice |
| 1–2 tells / 100 words | **Mixed** (default) | Tier 1 at full strength, Tier 2 on clear hits |
| 3+ tells / 100 words | **Full** | All 29 rules |

## Why

The current behavior is all-or-nothing: every rule runs on every text. This works well on AI-first drafts but over-corrects on human-first writing — personal journals, rough drafts, and meeting notes where fragments, first-person voice, and colloquialisms are intentional voice choices, not AI tells.

The density check makes humanizer safe to run on any input without worrying about destroying authentic voice.

## What defines Tier 1

For the pre-check, Tier 1 = the dead giveaways: patterns 1 (significance inflation), 3 (-ing phrase pile-up), 4 (promotional language), 7 (AI vocabulary words), 8 (copula avoidance), and 20 (chatbot artifacts). These are the highest-signal, lowest-false-positive tells.

## Testing

Tested in production on a personal journal corpus (~2,400 entries over several years). Light pass mode stops the "humanizer made my writing worse" failure mode cleanly on human-first content. The mixed/full threshold of 3 tells/100 words comes from empirical observation — most fully AI-generated paragraphs hit this easily; human-written paragraphs rarely do.

Closes #93