### PR TITLE
Add Register Awareness section + register-shifting checkpoint

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -513,27 +513,39 @@ If the input mixes languages (e.g. Chinese narrative with English code identifie
 ## Process
 
 1. Read the input text carefully
-2. Identify all instances of the patterns above
-3. Rewrite each problematic section
-4. Ensure the revised text:
+2. Classify the register using the Quick triage in Register Awareness
+3. Identify all instances of the patterns above, applying register overrides
+4. Rewrite each problematic section
+5. Ensure the revised text:
    - Sounds natural when read aloud
    - Varies sentence structure naturally
    - Uses specific details over vague claims
-   - Maintains appropriate tone for context
+   - Maintains appropriate tone for context (keep scholarly verbs in scholarly prose)
    - Uses simple constructions (is/are/has) where appropriate
-5. Present a draft humanized version
-6. Prompt: "What makes the below so obviously AI generated?"
-7. Answer briefly with the remaining tells (if any)
-8. Prompt: "Now make it not obviously AI generated."
-9. Present the final version (revised after the audit)
+6. Present a draft humanized version
+7. Prompt: "What makes the below so obviously AI generated?"
+8. Answer briefly with the remaining tells (if any)
+9. Prompt: "Now make it not obviously AI generated."
+10. Present the final version (revised after the audit)
+11. **Register-shifting edits checkpoint:** scan the diff between input and final. If any of the changes below were made, list them as separate bullets (`original phrase` → `rewritten phrase`) and ask the user whether to keep each one before treating delivery as final:
+    - Person change (we ↔ I, third-person ↔ first-person)
+    - Hyphen stripped from a compound modifier
+    - Scholarly verb informalized (shows / demonstrates / preserves / reports / presents → lands / dresses up / pulls off / etc.)
+    - Em dash removed from academic prose
+    - Voice or opinion injected into multi-author or scholarly prose
+    - Technical term replaced with a bland equivalent
+
+    If no such edits were made, state "No register-shifting edits flagged" and skip the question. When the user is unreachable (batch mode, automation), default to keeping the original wording for any flagged edit and note that you reverted them.
 
 ## Output Format
 
 Provide:
-1. Draft rewrite
-2. "What makes the below so obviously AI generated?" (brief bullets)
-3. Final rewrite
-4. A brief summary of changes made (optional, if helpful)
+1. **Register classification** — one line stating the register you classified the input as (academic / technical / quote / conversational / default)
+2. Draft rewrite
+3. "What makes the below so obviously AI generated?" (brief bullets)
+4. Final rewrite
+5. **Flagged register-shifting edits** — list per checkpoint above, or "No register-shifting edits flagged"
+6. A brief summary of changes made (optional, if helpful)
 
 
 ## Full Example

--- a/SKILL.md
+++ b/SKILL.md
@@ -23,17 +23,7 @@ allowed-tools:
 
 You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
 
-## Your Task
-
-When given text to humanize:
-
-1. **Identify AI patterns** - Scan for the patterns listed below
-2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
-3. **Preserve meaning** - Keep the core message intact
-4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
-5. **Add soul** - Don't just remove bad patterns; inject actual personality
-6. **Do a final anti-AI pass** - Prompt: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise
-
+The full step-by-step workflow lives in [Process](#process). The numbered steps below are the canonical sequence — read Voice Calibration, Personality and Soul, Register Awareness, and the rule sections first, then execute Process. Output Format defines what to deliver.
 
 ## Voice Calibration (Optional)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,6 +89,53 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
 
 
+## Register Awareness — Read Before Applying Rules
+
+The patterns below assume blog, marketing, encyclopedic, or conversational prose. Before rewriting, identify the register of the input. Some rules misfire on academic, technical, code, or quoted material, and applying them blindly damages writing more than it helps.
+
+### Quick triage
+
+Inspect the input and pick one register before editing:
+
+1. **Academic / scholarly prose** — multi-author paper, has citations or `\cite{}` / `\ref{}` markers, uses third-person plural "we", names methods or results, uses domain compound modifiers (e.g. "cold-cache compile time", "per-contract dispatch identity"). LaTeX source counts.
+2. **Technical / code-adjacent prose** — fenced code blocks, function names, file paths, command examples, API documentation, release notes that name internal systems.
+3. **Direct quote, citation, or reference** — text inside quotation marks attributed to someone else, bibliography entries, transcribed dialogue.
+4. **Conversational / personal** — first-person singular, casual tone, opinions stated directly.
+5. **Default (blog / marketing / encyclopedic)** — none of the above. Apply all rules.
+
+When in doubt, default to blog/marketing **and note in the changes summary that you assumed default register**, so the user can correct you.
+
+### Rules SAFE in every register
+
+These remove pure formatting noise or chatbot artifacts and have no register-dependent failure mode. Apply them everywhere:
+
+rule 18 (Emojis), rule 19 (Curly quotation marks), rule 20 (Collaborative communication artifacts), rule 21 (Knowledge-cutoff disclaimers), rule 22 (Sycophantic / servile tone), rule 28 (Signposting and announcements), rule 29 (Fragmented headers).
+
+### Restraint required in academic / technical register
+
+When the input is academic or technical, apply the following overrides:
+
+- **Rule 26 (Hyphenated word pair overuse) — DO NOT strip** compound modifiers that are domain conventions in the field. Compounds like `cold-cache compile time`, `per-contract dispatch identity`, `end-to-end retries`, `client-facing tools`, `data-driven report`, `cross-functional team` function as single technical units. Removing the hyphens forces readers to re-parse constituent boundaries and creates real syntactic ambiguity. Only consider stripping in informal prose where the compound is also generic.
+- **Personality and Soul section — DO NOT inject** first-person singular voice ("I keep coming back to…", "I genuinely don't know how to feel"), opinionated reactions, or casual asides. Multi-author papers use "we", and scholarly prose stays third-person. Adding voice here breaks the intended register and corrupts the authorial collective.
+- **Rule 8 (Copula avoidance) — apply selectively.** Phrases like "X represents Y" can be precise scholarly framing, not ceremonial inflation. Distinguish: strip "stands as a testament", but keep "represents a measured systems effect" — the latter is making a real claim.
+- **Rule 14 (Em dashes) — apply selectively.** Academic prose sometimes uses em dashes for parenthetical asides where commas would create syntactic ambiguity. Check whether the alternative actually reads cleaner before swapping.
+- **Rule 10 (Rule of three) — check first.** The original may genuinely list three things (three benchmarks, three contributions, three results axes). Strip the rule of three only when the trio is rhetorical filler, not when it is a real enumeration tied to the substance.
+- **Verb register — preserve scholarly verbs.** Do not informalize "shows / demonstrates / preserves / reports / presents" into "lands / dresses up / pulls off". Precise reporting verbs are part of the contract with the reader in research writing.
+- **Person — never switch person.** If the original uses "we", do not rewrite to "I". If it uses third-person, do not rewrite to first-person.
+
+### Skip rules entirely for these inputs
+
+- **Code blocks, function names, file paths, command examples** — leave verbatim. Only humanize the surrounding prose.
+- **Direct quotes from another source** — leave the quoted text exactly as written. Apply rules only to the framing narrative.
+- **Bibliography entries / citations / reference lists** — leave verbatim.
+
+### Mixed-language inputs
+
+If the input mixes languages (e.g. Chinese narrative with English code identifiers, or English prose with quoted non-English text), humanize each language segment by its own conventions. Do not translate or romanize. Do not strip diacritics or accents.
+
+---
+
+
 ## CONTENT PATTERNS
 
 ### 1. Undue Emphasis on Significance, Legacy, and Broader Trends


### PR DESCRIPTION
## Summary

Three commits adding register-aware restraint to `humanizer` so it does not over-edit academic, technical, or code-adjacent prose. Discovered while running an autonomous skill-optimization loop (Karpathy autoresearch pattern, 8-dimension rubric scored from 70.9 baseline → 85.75 after these changes).

## Commits

1. `074345a` — **add Register Awareness section** (between Personality and Soul and Content Patterns). Lists 5 register types (academic / technical / quote / code / default), names which rules are SAFE in every register, and which need restraint in academic/technical (rule 26 hyphens, rule 8 copula, rule 14 em dashes, rule 10 rule-of-three, scholarly verbs, person preservation).

2. `f3c8c98` — **add Process step 11: register-shifting edits checkpoint**. Six categories of edits to flag (person change, hyphen stripped, scholarly verb informalized, em dash removed from academic prose, voice injected, technical term replaced). Includes a batch-mode fallback that defaults to keeping the original wording when the user is unreachable. Updates Output Format with `Register classification` and `Flagged register-shifting edits` items.

3. `f41073b` — **remove Your Task / Process duplication**. The top-of-file 6-step \"Your Task\" list duplicated the Process section; replaced with a one-line pointer to Process as the canonical sequence.

## Net effect

- 559 → 608 lines (+49)
- All 29 numbered rule patterns unchanged (verified with `git log -p | grep -E '^[+-]### [0-9]+\.'`)
- Hyphenated technical compounds (`per-contract`, `cold-cache`, `native-artifact`, `micro-level`), academic plural `we`, and scholarly verbs (`shows`, `reports`, `preserves`) now correctly survive editing of academic input

## Verification

Tested on three prompts: AI-flavored blog (happy path), academic LaTeX paragraph from a real systems paper (restraint test), and product release note (formatting noise). The academic prompt's 4 hyphenated compounds and \"We report that speedup as an observed systems effect\" hedge are now preserved across the optimized humanizer pass.

Test artifacts and per-round scoring matrix live at https://github.com/alchaincyf/darwin-skill (see runs/humanizer-20260427/FINAL_REPORT.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)