### PR TITLE
ci: harden workflows, add zizmor, dependabot, codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+* @thilak-rao
+
+SKILL.md @thilak-rao
+/harnesses/ @thilak-rao
+/references/patterns.md @thilak-rao
+/scripts/ @thilak-rao
+/.github/ @thilak-rao

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Something in the skill misbehaves
+labels: bug
+---
+
+**Harness:** Claude Code / Codex / Cursor / Gemini / OpenCode / other:
+**Harness version:**
+**Slop or Not version (run `slop --version` if CLI):**
+
+**What did you do?**
+
+**What did you expect?**
+
+**What happened?**
+
+**Loop history (paste the table from the output, if any):**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a new harness, strategy, or option
+labels: enhancement
+---
+
+**Which kind of request?**
+
+- [ ] New harness routing
+- [ ] New per-iteration strategy
+- [ ] New interview option
+- [ ] Other
+
+**What problem does it solve?**
+
+**Proposed shape:**
+
+**Alternatives considered:**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci
+      include: scope
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/lint-skill.yml
+++ b/.github/workflows/lint-skill.yml
@@ -1,0 +1,29 @@
+name: lint-skill
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install markdownlint-cli2
+        run: npm install -g markdownlint-cli2@0.18.1
+
+      - name: Markdownlint
+        run: markdownlint-cli2 "**/*.md" "#node_modules" "#WARP.md"
+
+      - name: Frontmatter check
+        run: node scripts/check-frontmatter.mjs
+
+      - name: Relative-link check
+        run: node scripts/check-links.mjs

--- a/.github/workflows/lint-skill.yml
+++ b/.github/workflows/lint-skill.yml
@@ -5,22 +5,30 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-skill-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
 
-      - name: Install markdownlint-cli2
-        run: npm install -g markdownlint-cli2@0.18.1
-
       - name: Markdownlint
-        run: markdownlint-cli2 "**/*.md" "#node_modules" "#WARP.md"
+        run: npx -y markdownlint-cli2@0.18.1 "**/*.md" "#node_modules" "#WARP.md"
 
       - name: Frontmatter check
         run: node scripts/check-frontmatter.mjs

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,33 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Editor
+.vscode/
+.idea/
+.DS_Store
+
+# Local notes — not committed
+notes/
+*.local.md
+
+# Smoke-test outputs
+examples/output-*.md

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,8 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD024": { "siblings_only": true },
+  "MD033": false,
+  "MD041": false,
+  "MD046": { "style": "fenced" }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# Agentic Humanizer: agent guide
+
+Brief for AI coding agents (Claude Code, Codex, Cursor, Gemini CLI, Aider) editing this repo. The runtime skill itself is `SKILL.md`; this file is for agents working *on* the repo, not running the skill.
+
+## What this repo is
+
+A community fork of [`blader/humanizer`](https://github.com/blader/humanizer) that wraps the upstream 29-pattern rewrite playbook in an iterative AI-detection loop scored by Slop or Not Pro's on-device CLI / MCP. Single skill, no build step, all Markdown.
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `SKILL.md` | Skill orchestrator. Steps 1–5 (harness detect → Pro probe → interview → loop → output). |
+| `harnesses/{claude-code,codex,cursor,gemini-cli,opencode,generic}.md` | Per-harness interview protocols. Edit only the file for the harness you're targeting. |
+| `references/patterns.md` | 29-pattern rewrite vocabulary, **synced verbatim from upstream**. Local divergence is out of scope. |
+| `references/per-iteration-strategies.md` | The 5-iteration cookbook + mid-flight Pro-gate fallback. |
+| `references/slop-{cli,mcp}-setup.md` | User-facing install guides. |
+| `examples/sample-ai-text.md` | Smoke-test fixture. |
+| `scripts/check-{frontmatter,links}.mjs` | Lint scripts run by CI. |
+
+## Critical rules
+
+1. **Pre-PR gate**, these three must pass:
+
+   ```bash
+   npx markdownlint-cli2@0.18.1 "**/*.md" "#node_modules" "#WARP.md"
+   node scripts/check-frontmatter.mjs
+   node scripts/check-links.mjs
+   ```
+
+2. **No em-dashes in `README.md`, `SKILL.md`, `CHANGELOG.md`, `AGENTS.md`, commits, tag annotations, or release notes.** Use commas, colons, or parentheses. The user-facing surface of a humanizer can't credibly ship em-dash-laden copy. (Inherited em-dashes in `references/` and `harnesses/` predate the rule and are getting cleaned up incrementally; do not introduce new ones.)
+3. **Don't edit `references/patterns.md` for local taste.** Only sync from upstream `blader/humanizer`. The 29 patterns are upstream's contribution.
+4. **Conventional Commits**: `type(scope): subject`. Common scopes: `harnesses`, `references`, `docs`, `ci`, `chore`. Subject is imperative, lowercase, no trailing period.
+5. **Keep `SKILL.md` and `README.md` in sync** when you change a runtime constant (`AI_THRESHOLD`, `MAX_ITER`, grade tolerance), the interview shape, the output format, or the inline-override grammar. Stale runtime docs mislead users.
+6. **Don't add new per-iteration strategies that replace the 5-iteration schedule.** New strategies must compose with it. Open an issue first.
+7. **Harness-specific instructions stay in `harnesses/<name>.md`.** Don't sprinkle "Claude Code users…" / "Codex users…" through the top-level SKILL.md.
+
+## Smoke test
+
+```text
+/agentic-humanizer
+<paste contents of examples/sample-ai-text.md>
+```
+
+Expect convergence by iteration 3 or 4 on the sample fixture. Output structure must match `SKILL.md` § Step 5.
+
+## Out of scope
+
+- Adding new detectors. The loop is intentionally Slop or Not Pro only.
+- Cloud-detector benchmarking (GPTZero, Originality, Pangram). README § "Will it bypass…" is the canonical answer.
+- Voice-calibration mode. Tracked under Roadmap; needs design before code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,40 @@ A community fork of [`blader/humanizer`](https://github.com/blader/humanizer) th
 
 2. **No em-dashes in `README.md`, `SKILL.md`, `CHANGELOG.md`, `AGENTS.md`, commits, tag annotations, or release notes.** Use commas, colons, or parentheses. The user-facing surface of a humanizer can't credibly ship em-dash-laden copy. (Inherited em-dashes in `references/` and `harnesses/` predate the rule and are getting cleaned up incrementally; do not introduce new ones.)
 3. **Don't edit `references/patterns.md` for local taste.** Only sync from upstream `blader/humanizer`. The 29 patterns are upstream's contribution.
-4. **Conventional Commits**: `type(scope): subject`. Common scopes: `harnesses`, `references`, `docs`, `ci`, `chore`. Subject is imperative, lowercase, no trailing period.
-5. **Keep `SKILL.md` and `README.md` in sync** when you change a runtime constant (`AI_THRESHOLD`, `MAX_ITER`, grade tolerance), the interview shape, the output format, or the inline-override grammar. Stale runtime docs mislead users.
-6. **Don't add new per-iteration strategies that replace the 5-iteration schedule.** New strategies must compose with it. Open an issue first.
-7. **Harness-specific instructions stay in `harnesses/<name>.md`.** Don't sprinkle "Claude Code users…" / "Codex users…" through the top-level SKILL.md.
+4. **Conventional Commits are required, not optional.** Format: `type(scope): subject`. Subject is imperative, lowercase, no trailing period. Allowed types and their changelog mapping:
+
+   | Type | Changelog section | Use for |
+   |---|---|---|
+   | `feat` | Added | new behavior, new harness, new reference doc |
+   | `fix` | Fixed | bug fixes in scripts, lint rules, runtime logic |
+   | `perf` | Changed | measurable speed or token wins |
+   | `refactor` | Changed | restructuring without behavior change |
+   | `docs` | Changed (or omit) | `README`, `AGENTS.md`, `CHANGELOG`, `NOTICE`, `CONTRIBUTING` edits |
+   | `build` / `ci` | (omit) | workflow, lint config, release tooling |
+   | `test` | (omit) | adding or fixing tests and fixtures |
+   | `chore` | (omit) | housekeeping, dependency bumps |
+   | `revert` | matches reverted type | use `revert: <original subject>` |
+
+   Use `!` after the type/scope or a `BREAKING CHANGE:` footer for breaking changes (these always land in changelog under "Changed" with a "BREAKING" prefix). Common scopes: `harnesses`, `references`, `docs`, `ci`, `chore`, `scripts`. The changelog generator reads commit history, so a malformed subject silently drops the change from the next release notes.
+
+5. **Doc-sync is part of the change, not a follow-up.** Any PR that changes runtime behavior MUST update every affected surface in the same commit (or stack of commits). Use this matrix:
+
+   | What you changed | Update these in the same PR |
+   |---|---|
+   | Runtime constant (`AI_THRESHOLD`, `MAX_ITER`, grade tolerance) | `SKILL.md`, `README.md`, `CHANGELOG.md` (Unreleased) |
+   | Interview shape, question count, or order | `SKILL.md`, `README.md`, every `harnesses/*.md`, `CHANGELOG.md` |
+   | Output format (Step 5 structure, fields, ordering) | `SKILL.md`, `README.md`, `CHANGELOG.md` |
+   | Inline-override grammar or saved-profile schema | `SKILL.md`, `README.md`, `CHANGELOG.md` |
+   | New or renamed reference doc under `references/` | `SKILL.md` (links), `AGENTS.md` (Layout table), `scripts/check-links.mjs` if it hardcodes paths |
+   | Harness routing (added, removed, renamed harness) | `SKILL.md` Step 1, `harnesses/<name>.md`, `README.md`, `CHANGELOG.md` |
+   | Lint rules, CI gates, release scripts | `AGENTS.md` (Critical rules § 1), `CONTRIBUTING.md`, `CHANGELOG.md` |
+   | Slop CLI / MCP install steps | `references/slop-cli-setup.md` or `references/slop-mcp-setup.md`, `README.md`, `CHANGELOG.md` |
+
+   If you can't tell whether a doc is affected, grep it for the symbol you changed. Stale runtime docs mislead users and corrupt the changelog.
+
+6. **Every user-visible change appends to `CHANGELOG.md` § `[Unreleased]`** under the matching Keep-a-Changelog heading (`Added`, `Changed`, `Fixed`, `Removed`, `Deprecated`, `Security`). Internal-only changes (`ci`, `build`, `test`, `chore`) skip the changelog. The release script promotes `[Unreleased]` to a versioned section; missing entries can't be recovered after the tag.
+7. **Don't add new per-iteration strategies that replace the 5-iteration schedule.** New strategies must compose with it. Open an issue first.
+8. **Harness-specific instructions stay in `harnesses/<name>.md`.** Don't sprinkle "Claude Code users…" / "Codex users…" through the top-level `SKILL.md`.
 
 ## Smoke test
 
@@ -43,9 +73,3 @@ A community fork of [`blader/humanizer`](https://github.com/blader/humanizer) th
 ```
 
 Expect convergence by iteration 3 or 4 on the sample fixture. Output structure must match `SKILL.md` § Step 5.
-
-## Out of scope
-
-- Adding new detectors. The loop is intentionally Slop or Not Pro only.
-- Cloud-detector benchmarking (GPTZero, Originality, Pangram). README § "Will it bypass…" is the canonical answer.
-- Voice-calibration mode. Tracked under Roadmap; needs design before code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - README explanation of what Flesch-Kincaid reading level means, with a link
   to the Wikipedia overview.
 
+### Changed
+
+- README and `references/slop-cli-setup.md` now document the `slop status`
+  field as `pro` (renamed from the legacy `premium`). The runtime probe
+  was already robust because it calls `detect_text` directly, so neither
+  CLI nor MCP behavior changes.
+
 ## [0.1.0] (2026-05-07)
 
 Initial release. Forked from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [0.1.0] (2026-05-DD)
+## [0.1.0] (2026-05-07)
 
 Initial release. Forked from
 [`blader/humanizer`](https://github.com/blader/humanizer) by Siqi Chen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `AGENTS.md` agent guide for contributors, with `CLAUDE.md` symlinked to it.
+- Saved-preferences profile at `~/.agentic-humanizer/profile.json`. After
+  the first interview the skill offers to remember your answers; subsequent
+  runs skip the interview silently. Manage via `/agentic-humanizer show profile`,
+  `/agentic-humanizer reset`, and `/agentic-humanizer set dialect=... grade=... tone=... length=...`.
+- README explanation of what Flesch-Kincaid reading level means, with a link
+  to the Wikipedia overview.
+
 ## [0.1.0] (2026-05-07)
 
 Initial release. Forked from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to Agentic Humanizer are documented here. The format
+is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+## [0.1.0] (2026-05-DD)
+
+Initial release. Forked from
+[`blader/humanizer`](https://github.com/blader/humanizer) by Siqi Chen.
+
+### Added
+
+- `SKILL.md` orchestrating harness detection, Slop or Not Pro probe,
+  4-question interview, and 5-iteration rewrite loop.
+- Harness routing files for Claude Code, Codex CLI, Cursor, Gemini CLI,
+  OpenCode, and a generic plain-text fallback.
+- `references/patterns.md` (29 AI-tells from upstream, attributed).
+- `references/per-iteration-strategies.md` (per-iteration cookbook).
+- `references/slop-cli-setup.md` and `references/slop-mcp-setup.md`
+  (install guides).
+- `examples/sample-ai-text.md` smoke-test fixture.
+- GitHub Actions CI for markdownlint, frontmatter validation, and
+  relative-link checking.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,49 @@
 # Contributing
 
-Full contributing guide ships in v0.1.0. See `CHANGELOG.md` and the open
-issues in the meantime.
+Thanks for your interest in Agentic Humanizer.
+
+## Scope of contributions
+
+- New harness routing files (`harnesses/<name>.md`) are welcome.
+- New per-iteration strategies are welcome, but they should compose with
+  the existing 5-iteration schedule, not replace it. Open an issue first
+  to discuss.
+- Edits to `references/patterns.md` only if syncing from upstream
+  `blader/humanizer`. Local divergence on the 29 patterns is out of
+  scope; the substantive playbook is upstream's.
+
+## Pre-PR checklist
+
+```bash
+npx markdownlint-cli2@0.18.1 "**/*.md" "#node_modules" "#WARP.md"
+node scripts/check-frontmatter.mjs
+node scripts/check-links.mjs
+```
+
+All three must pass.
+
+## Smoke test
+
+```text
+/agentic-humanizer
+<paste contents of examples/sample-ai-text.md>
+```
+
+Verify the output structure matches `SKILL.md` § Step 5. Expect the loop
+to reach iteration 3 or 4 before converging on the sample fixture.
+
+## Commit conventions
+
+Conventional Commits: `type(scope): subject`. Common types:
+
+- `feat(harnesses)`: new harness routing
+- `feat(references)`: new or updated reference doc
+- `docs`: README, NOTICE, CHANGELOG edits
+- `ci`: workflow and lint config changes
+- `chore`: housekeeping
+
+## Code of conduct
+
+Be respectful. Issues that argue about academic-integrity ethics or
+school-policy enforcement will be closed without engagement, since this
+repository is a tool, not a debate forum. Report abuse via GitHub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+Full contributing guide ships in v0.1.0. See `CHANGELOG.md` and the open
+issues in the meantime.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2025 Siqi Chen
+Copyright (c) 2026 Thilak Rao
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,19 @@
+Agentic Humanizer
+
+This project is a community fork of blader/humanizer, originally created
+by Siqi Chen. The 29-pattern rewrite playbook in references/patterns.md
+is derived from the upstream work and is used here under the MIT License.
+
+Upstream repository:
+  https://github.com/blader/humanizer
+
+Agentic Humanizer extends the upstream skill with:
+  - An iterative detection loop scored by Slop or Not Pro's on-device
+    AI detector (detect_text) and Flesch-Kincaid analyzer
+    (analyze_readability).
+  - A 4-question pre-loop interview (dialect, reading level, tone, length).
+  - Multi-harness routing for Claude Code, OpenCode, Codex, Cursor, and
+    Gemini CLI.
+
+The detection loop is gated behind Slop or Not Pro for Mac:
+  https://slopornot.ai/download

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ into a slash command in your AI assistant (Claude Code, Codex CLI,
 Cursor, Gemini CLI, or OpenCode), and the skill rewrites it iteratively
 until two targets are met:
 
-1. The output's AI-generation probability falls below 30% per Slop or
+1. The output's AI-generation probability falls below 40% per Slop or
    Not's on-device detector.
 2. The Flesch-Kincaid reading level is within ±1 grade of the target you
    pick (Elementary, Middle, High school, College, or Graduate).
@@ -43,7 +43,7 @@ Iteration 3   grade gap      (close the Flesch-Kincaid distance)
 Iteration 4   clean + targeted (clean_text + residual signal)
 Iteration 5   emergency surgery (sentence shapes, broken rule-of-three)
 
-Stop when AI score ≤ 30% AND |grade - target| ≤ 1
+Stop when AI score ≤ 40% AND |grade - target| ≤ 1
    OR after iteration 5.
 ```
 
@@ -55,25 +55,32 @@ may be cloud or local depending on which one you use.
 
 ## Install
 
-One clone per harness. The same repository works in every harness; only
-the install location differs.
+### Recommended (Claude Code, Cursor, Windsurf)
 
 ```bash
-# Claude Code + OpenCode (one clone covers both)
-mkdir -p ~/.claude/skills && \
-  git clone https://github.com/thilak-rao/agentic-humanizer ~/.claude/skills/agentic-humanizer
+npx skills add thilak-rao/agentic-humanizer
+```
 
+The [skills.sh](https://skills.sh) CLI downloads the skill and configures
+it for your harness automatically. No manual path wrangling.
+
+### Manual install (Codex CLI, Gemini CLI, OpenCode)
+
+skills.sh does not yet ship native support for these harnesses. Clone
+into the harness's skill directory directly:
+
+```bash
 # Codex CLI
 mkdir -p ~/.codex/skills && \
   git clone https://github.com/thilak-rao/agentic-humanizer ~/.codex/skills/agentic-humanizer
 
-# Cursor 2.4+, project-local install
-mkdir -p .agents/skills && \
-  git clone https://github.com/thilak-rao/agentic-humanizer .agents/skills/agentic-humanizer
-
 # Gemini CLI
 mkdir -p ~/.gemini/skills && \
   git clone https://github.com/thilak-rao/agentic-humanizer ~/.gemini/skills/agentic-humanizer
+
+# OpenCode (if not running via skills.sh)
+mkdir -p ~/.config/opencode/skills && \
+  git clone https://github.com/thilak-rao/agentic-humanizer ~/.config/opencode/skills/agentic-humanizer
 ```
 
 After cloning, restart your harness so the skill is discovered.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Verify:
 slop status --json
 ```
 
-Should print `{"premium": true, ...}`. If `premium: false`, finish step 2.
+Should print `{"pro": true, ...}` on recent builds (older builds use the
+legacy `"premium": true` field). If the value is `false`, finish step 2.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,13 @@ until two targets are met:
 
 1. The output's AI-generation probability falls below 40% per Slop or
    Not's on-device detector.
-2. The Flesch-Kincaid reading level is within ±1 grade of the target you
-   pick (Elementary, Middle, High school, College, or Graduate).
+2. The [Flesch-Kincaid reading level](https://en.wikipedia.org/wiki/Flesch%E2%80%93Kincaid_readability_tests)
+   is within ±1 grade of the target you pick (Elementary, Middle, High
+   school, College, or Graduate). Flesch-Kincaid is a standard readability
+   formula that maps text to a US school grade level based on average
+   sentence length and syllables per word: shorter sentences and simpler
+   words mean a lower grade. Picking "High school" tells the loop to aim
+   for grade 9-11 prose.
 
 It is not a one-shot rewriter. It is an agentic loop: detect, rewrite,
 re-detect, repeat, up to 5 iterations with a different strategy on each
@@ -152,6 +157,24 @@ Professional · ±10%):
 ```text
 /agentic-humanizer skip-interview [paste]
 ```
+
+### Save your preferences once
+
+After the first interview, the skill offers to save your four answers
+(dialect, reading level, tone, length) to `~/.agentic-humanizer/profile.json`.
+Say yes and you will never be interviewed again on the same machine. Inline
+overrides still work for one-off changes without touching the saved
+profile.
+
+```text
+/agentic-humanizer show profile     # print the saved profile
+/agentic-humanizer reset            # delete the saved profile
+/agentic-humanizer set dialect=uk grade=10 tone=casual length=±10
+                                    # write a profile without the interview
+```
+
+The profile lives at `~/.agentic-humanizer/profile.json` as plain JSON.
+Edit it directly if you prefer.
 
 ## How is this different from `blader/humanizer`?
 

--- a/README.md
+++ b/README.md
@@ -1,194 +1,223 @@
-# Humanizer
+# Agentic Humanizer: a Claude, Codex, Cursor, and Gemini humanizer skill that loops until your text passes AI detection
 
-A skill for Claude Code and OpenCode that removes signs of AI-generated writing from text, making it sound more natural and human.
+A community fork of [`blader/humanizer`](https://github.com/blader/humanizer)
+by Siqi Chen. Each iteration scores the rewrite with Slop or Not Pro's
+on-device AI detector and Flesch-Kincaid analyzer. Detection stays local;
+rewriting runs wherever your AI assistant runs.
 
-## Installation
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-### Claude Code
+## What is this?
 
-Clone directly into Claude Code's skills directory:
+Agentic Humanizer is an AI humanizer skill. You paste AI-generated text
+into a slash command in your AI assistant (Claude Code, Codex CLI,
+Cursor, Gemini CLI, or OpenCode), and the skill rewrites it iteratively
+until two targets are met:
 
-```bash
-mkdir -p ~/.claude/skills
-git clone https://github.com/blader/humanizer.git ~/.claude/skills/humanizer
+1. The output's AI-generation probability falls below 30% per Slop or
+   Not's on-device detector.
+2. The Flesch-Kincaid reading level is within ±1 grade of the target you
+   pick (Elementary, Middle, High school, College, or Graduate).
+
+It is not a one-shot rewriter. It is an agentic loop: detect, rewrite,
+re-detect, repeat, up to 5 iterations with a different strategy on each
+pass (pattern surgery, dialect + tone, grade gap, clean + targeted,
+emergency surgery).
+
+If you do not have Slop or Not Pro installed, the skill still humanizes
+in a single pass using upstream's 29-pattern rewrite playbook and points
+you to the download.
+
+## How the detection loop works
+
+```text
+You paste text.
+
+Skill probes for Slop or Not Pro (MCP first, CLI second).
+Skill asks 4 questions: dialect, reading level, tone, length.
+
+Iteration 0   baseline       detect_text + analyze_readability
+Iteration 1   pattern surgery (top-5 of upstream's 29 AI-tells)
+Iteration 2   dialect + tone (US/UK spellings, casual/pro/academic)
+Iteration 3   grade gap      (close the Flesch-Kincaid distance)
+Iteration 4   clean + targeted (clean_text + residual signal)
+Iteration 5   emergency surgery (sentence shapes, broken rule-of-three)
+
+Stop when AI score ≤ 30% AND |grade - target| ≤ 1
+   OR after iteration 5.
 ```
 
-Or copy the skill file manually if you already have this repo cloned:
+Tools the loop uses: `detect_text`, `analyze_readability`, `clean_text`
+(MCP) or `slop text`, `slop readability`, `slop cleanup` (CLI). Both run
+on-device on Apple silicon. Your text is not uploaded to any server for
+the *detection* step. Rewriting still runs in your AI assistant, which
+may be cloud or local depending on which one you use.
+
+## Install
+
+One clone per harness. The same repository works in every harness; only
+the install location differs.
 
 ```bash
-mkdir -p ~/.claude/skills/humanizer
-cp SKILL.md ~/.claude/skills/humanizer/
+# Claude Code + OpenCode (one clone covers both)
+mkdir -p ~/.claude/skills && \
+  git clone https://github.com/thilak-rao/agentic-humanizer ~/.claude/skills/agentic-humanizer
+
+# Codex CLI
+mkdir -p ~/.codex/skills && \
+  git clone https://github.com/thilak-rao/agentic-humanizer ~/.codex/skills/agentic-humanizer
+
+# Cursor 2.4+, project-local install
+mkdir -p .agents/skills && \
+  git clone https://github.com/thilak-rao/agentic-humanizer .agents/skills/agentic-humanizer
+
+# Gemini CLI
+mkdir -p ~/.gemini/skills && \
+  git clone https://github.com/thilak-rao/agentic-humanizer ~/.gemini/skills/agentic-humanizer
 ```
 
-### OpenCode
+After cloning, restart your harness so the skill is discovered.
 
-Clone directly into OpenCode's skills directory:
+## Setup Slop or Not Pro
+
+The agentic loop is gated behind Slop or Not Pro for Mac, which ships
+the `slop` CLI and `slop mcp` MCP server.
+
+1. Install Slop or Not for Mac: <https://slopornot.ai/download>
+2. Open the app and unlock Pro from Settings → Subscription.
+3. Symlink the binary onto your PATH:
+
+   ```bash
+   mkdir -p ~/.local/bin
+   ln -sf "/Applications/Slop Or Not - AI Fake Detector.app/Contents/MacOS/slop" \
+     ~/.local/bin/slop
+   ```
+
+4. Optionally register `slop mcp` with your AI client. See
+   [`references/slop-mcp-setup.md`](references/slop-mcp-setup.md) for
+   per-harness configuration snippets.
+
+Verify:
 
 ```bash
-mkdir -p ~/.config/opencode/skills
-git clone https://github.com/blader/humanizer.git ~/.config/opencode/skills/humanizer
+slop status --json
 ```
 
-Or copy the skill file manually if you already have this repo cloned:
-
-```bash
-mkdir -p ~/.config/opencode/skills/humanizer
-cp SKILL.md ~/.config/opencode/skills/humanizer/
-```
-
-> **Note:** OpenCode also scans `~/.claude/skills/` for compatibility, so a single clone into `~/.claude/skills/humanizer/` works for both tools.
+Should print `{"premium": true, ...}`. If `premium: false`, finish step 2.
 
 ## Usage
 
-### Claude Code
-
-```
-/humanizer
-
-[paste your text here]
+```text
+/agentic-humanizer
+[paste your AI-generated text here]
 ```
 
-### OpenCode
+The skill asks four quick questions, then runs the loop and returns:
 
-```
-/humanizer
+```markdown
+## Humanized text
+<the rewritten text>
 
-[paste your text here]
-```
+## Loop history
+| Iter | AI score | Grade | Strategy           |
+|------|----------|-------|--------------------|
+| 0    |  92%     | 11.4  | baseline           |
+| 1    |  71%     | 10.8  | pattern surgery    |
+| 2    |  48%     | 10.4  | dialect + tone     |
+| 3    |  27%     |  9.7  | grade gap          |
+✓ Converged at iter 3.
 
-Or ask the model to humanize text directly in either tool:
-
-```
-Please humanize this text: [your text]
-```
-
-### Voice Calibration
-
-To match your personal writing style, provide a sample of your own writing:
-
-```
-/humanizer
-
-Here's a sample of my writing for voice matching:
-[paste 2-3 paragraphs of your own writing]
-
-Now humanize this text:
-[paste AI text to humanize]
+## Highest-impact edits
+- ...
 ```
 
-The skill will analyze your sentence rhythm, word choices, and quirks, then apply them to the rewrite instead of producing generic "clean" output.
+### Inline overrides
 
-## Overview
+Skip the interview by passing flags directly:
 
-Based on [Wikipedia's "Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) guide, maintained by WikiProject AI Cleanup. This comprehensive guide comes from observations of thousands of instances of AI-generated text.
+```text
+/agentic-humanizer dialect=us grade=8 tone=casual length=±10 threshold=20 max=7 [paste]
+```
 
-The skill also includes a final "obviously AI generated" audit pass and a second rewrite, to catch lingering AI-isms in the first draft.
+Or just skip the interview and use defaults (American · High school ·
+Professional · ±10%):
 
-### Key Insight from Wikipedia
+```text
+/agentic-humanizer skip-interview [paste]
+```
 
-> "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
+## How is this different from `blader/humanizer`?
 
-## 29 Patterns Detected (with Before/After Examples)
+The upstream `blader/humanizer` is a one-shot rewriter: it applies the
+29-pattern playbook and returns the result.
 
-### Content Patterns
+Agentic Humanizer adds three things on top:
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 1 | **Significance inflation** | "marking a pivotal moment in the evolution of..." | "was established in 1989 to collect regional statistics" |
-| 2 | **Notability name-dropping** | "cited in NYT, BBC, FT, and The Hindu" | "In a 2024 NYT interview, she argued..." |
-| 3 | **Superficial -ing analyses** | "symbolizing... reflecting... showcasing..." | Remove or expand with actual sources |
-| 4 | **Promotional language** | "nestled within the breathtaking region" | "is a town in the Gonder region" |
-| 5 | **Vague attributions** | "Experts believe it plays a crucial role" | "according to a 2019 survey by..." |
-| 6 | **Formulaic challenges** | "Despite challenges... continues to thrive" | Specific facts about actual challenges |
+- **Iterative scoring loop.** Each rewrite is measured by Slop or Not
+  Pro's on-device detector and readability analyzer, so you can see the
+  loop converging from 92% → 71% → 48% → 27% AI score across iterations.
+- **Different strategy per iteration.** Five strategies in a fixed
+  schedule, not the same edit twice. The schedule is documented in
+  [`references/per-iteration-strategies.md`](references/per-iteration-strategies.md).
+- **Pre-loop interview.** Four questions (dialect, reading level, tone,
+  length) so the rewrite targets a specific reader, not a generic one.
 
-### Language Patterns
+The 29 patterns themselves are unchanged from upstream. They live in
+[`references/patterns.md`](references/patterns.md) with attribution.
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 7 | **AI vocabulary** | "Actually... additionally... testament... landscape... showcasing" | "also... remain common" |
-| 8 | **Copula avoidance** | "serves as... features... boasts" | "is... has" |
-| 9 | **Negative parallelisms / tailing negations** | "It's not just X, it's Y", "..., no guessing" | State the point directly |
-| 10 | **Rule of three** | "innovation, inspiration, and insights" | Use natural number of items |
-| 11 | **Synonym cycling** | "protagonist... main character... central figure... hero" | "protagonist" (repeat when clearest) |
-| 12 | **False ranges** | "from the Big Bang to dark matter" | List topics directly |
-| 13 | **Passive voice / subjectless fragments** | "No configuration file needed" | Name the actor when it helps clarity |
+## Will it bypass GPTZero / ZeroGPT / Pangram / Originality.ai?
 
-### Style Patterns
+The loop is designed against Slop or Not's on-device detector. Slop or
+Not reports 95% accuracy on AI text and 90% on AI images per their
+internal tests, with the caveat that *"results can vary with new AI
+models and advanced methods designed to trick detectors"* (per the
+slopornot.ai disclaimer).
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 14 | **Em dash overuse** | "institutions—not the people—yet this continues—" | Prefer commas or periods |
-| 15 | **Boldface overuse** | "**OKRs**, **KPIs**, **BMC**" | "OKRs, KPIs, BMC" |
-| 16 | **Inline-header lists** | "**Performance:** Performance improved" | Convert to prose |
-| 17 | **Title Case Headings** | "Strategic Negotiations And Partnerships" | "Strategic negotiations and partnerships" |
-| 18 | **Emojis** | "🚀 Launch Phase: 💡 Key Insight:" | Remove emojis |
-| 19 | **Curly quotes** | `said “the project”` | `said “the project”` |
-| 26 | **Hyphenated word pairs** | “cross-functional, data-driven, client-facing” | Drop hyphens on common word pairs |
-| 27 | **Persuasive authority tropes** | "At its core, what matters is..." | State the point directly |
-| 28 | **Signposting announcements** | "Let's dive in", "Here's what you need to know" | Start with the content |
-| 29 | **Fragmented headers** | "## Performance" + "Speed matters." | Let the heading do the work |
+We do not benchmark against external detectors. Cross-detector
+generalization is real but not guaranteed. If your goal is bypassing a
+specific competitor detector, this skill is not the right tool for that
+job.
 
-### Communication Patterns
+## Why Slop or Not specifically?
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 20 | **Chatbot artifacts** | "I hope this helps! Let me know if..." | Remove entirely |
-| 21 | **Cutoff disclaimers** | "While details are limited in available sources..." | Find sources or remove |
-| 22 | **Sycophantic tone** | "Great question! You're absolutely right!" | Respond directly |
+- **On-device.** Detection runs on the Apple Neural Engine. Your text
+  never leaves your machine for the *detection* step.
+- **No word-count limits.** Most cloud detectors meter usage. Slop or
+  Not has no per-document word cap; the free tier limits *number* of
+  daily checks instead.
+- **Pro tier is one-time-or-subscription.** A Lifetime purchase removes
+  the daily check limit and unlocks the `slop` CLI and `slop mcp` MCP
+  server that this skill uses.
 
-### Filler and Hedging
+For the full feature surface, see <https://slopornot.ai>.
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 23 | **Filler phrases** | "In order to", "Due to the fact that" | "To", "Because" |
-| 24 | **Excessive hedging** | "could potentially possibly" | "may" |
-| 25 | **Generic conclusions** | "The future looks bright" | Specific plans or facts |
+## Roadmap
 
-## Full Example
+- Additional harnesses (AiderDesk, Continue, Roo Code).
+- Optional second-detector cross-check (when Slop or Not adds an MCP
+  client for external detectors).
+- Voice-calibration mode that learns the user's writing style from a
+  pasted sample, like upstream's voice-cal feature.
 
-**Before (AI-sounding):**
-> Great question! Here is an essay on this topic. I hope this helps!
->
-> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
->
-> At its core, the value proposition is clear: streamlining processes, enhancing collaboration, and fostering alignment. It's not just about autocomplete; it's about unlocking creativity at scale, ensuring that organizations can remain agile while delivering seamless, intuitive, and powerful experiences to users. The tool serves as a catalyst. The assistant functions as a partner. The system stands as a foundation for innovation.
->
-> Industry observers have noted that adoption has accelerated from hobbyist experiments to enterprise-wide rollouts, from solo developers to cross-functional teams. The technology has been featured in The New York Times, Wired, and The Verge. Additionally, the ability to generate documentation, tests, and refactors showcases how AI can contribute to better outcomes, highlighting the intricate interplay between automation and human judgment.
->
-> - 💡 **Speed:** Code generation is significantly faster, reducing friction and empowering developers.
-> - 🚀 **Quality:** Output quality has been enhanced through improved training, contributing to higher standards.
-> - ✅ **Adoption:** Usage continues to grow, reflecting broader industry trends.
->
-> While specific details are limited based on available information, it could potentially be argued that these tools might have some positive effect. Despite challenges typical of emerging technologies—including hallucinations, bias, and accountability—the ecosystem continues to thrive. In order to fully realize this potential, teams must align with best practices.
->
-> In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you’d like me to expand on any section!
+Open an issue if you want a specific harness or feature prioritized.
 
-**After (Humanized):**
-> AI coding assistants can speed up the boring parts of the job. They're great at boilerplate: config files and the little glue code you don't want to write. They can also help you sketch a test, but you still have to read it.
->
-> The dangerous part is how confident the suggestions look. I've accepted code that compiled and passed lint, then discovered later it missed the point because I stopped paying attention.
->
-> If you treat it like autocomplete and review every line, it's useful. If you use it to avoid thinking, it will help you ship bugs faster.
->
-> The only real backstop is tests. Without them, you're mostly judging vibes.
+## Credits & License
 
-## References
+This is a community fork of [`blader/humanizer`](https://github.com/blader/humanizer)
+by Siqi Chen. The 29-pattern rewrite playbook in
+[`references/patterns.md`](references/patterns.md) is reproduced verbatim
+from upstream under the MIT License. See [`NOTICE`](NOTICE) for full
+attribution.
 
-- [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) - Primary source
-- [WikiProject AI Cleanup](https://en.wikipedia.org/wiki/Wikipedia:WikiProject_AI_Cleanup) - Maintaining organization
+This fork is licensed under the [MIT License](LICENSE), with upstream's
+copyright preserved alongside the fork's.
 
-## Version History
+The agentic detection loop, harness routing, interview, and per-iteration
+strategy schedule are new in this fork. Slop or Not is a separate
+product by the author of this fork; see <https://slopornot.ai>.
 
-- **2.5.1** - Added a passive-voice / subjectless-fragment rule, raising the total to 29 patterns
-- **2.5.0** - Added patterns for persuasive framing, signposting, and fragmented headers; expanded negative parallelisms to cover tailing negations; tightened wording around em dash overuse; fixed frontmatter wording to use "filler phrases"
-- **2.4.0** - Added voice calibration: match the user's personal writing style from samples
-- **2.3.0** - Added pattern #25: hyphenated word pair overuse
-- **2.2.0** - Added a final "obviously AI generated" audit + second-pass rewrite prompts
-- **2.1.1** - Fixed pattern #18 example (curly quotes vs straight quotes)
-- **2.1.0** - Added before/after examples for all 24 patterns
-- **2.0.0** - Complete rewrite based on raw Wikipedia article content
-- **1.0.0** - Initial release
+## Contributing
 
-## License
-
-MIT
+See [`CONTRIBUTING.md`](CONTRIBUTING.md). New harness routing files
+welcome. PRs that change the 29-pattern catalogue should sync from
+upstream rather than diverging.

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,12 +31,12 @@ with an iterative AI-detection loop powered by Slop or Not Pro.
 2. Probes whether Slop or Not Pro is reachable via MCP or CLI.
 3. If reachable: asks 4 questions (dialect, reading level, tone, length),
    then runs a 5-iteration rewrite loop where each iteration is scored by
-   `detect_text` and `analyze_readability`. Stops when AI score ≤ 30%
+   `detect_text` and `analyze_readability`. Stops when AI score ≤ 40%
    AND Flesch-Kincaid grade is within ±1 of the user's target.
 4. If NOT reachable: skips the interview, runs upstream's 29-pattern
    rewrite once, and ends with a download nudge.
 
-## Step 1 — Detect the harness
+## Step 1: Detect the harness
 
 Identify which harness is running by checking for the harness's distinctive
 question tool. Use the first match:
@@ -48,11 +48,11 @@ question tool. Use the first match:
 | Cursor | `AskQuestion` | `harnesses/cursor.md` |
 | Gemini CLI | `ask_user` (or equivalent structured-question tool) | `harnesses/gemini-cli.md` |
 | OpenCode | OpenCode's built-in `question` tool, or AUQ MCP | `harnesses/opencode.md` |
-| Anything else | n/a — fall back to plain text | `harnesses/generic.md` |
+| Anything else | n/a; fall back to plain text | `harnesses/generic.md` |
 
 Do not load the harness file yet. Save the choice for Step 3.
 
-## Step 2 — Probe Slop or Not Pro
+## Step 2: Probe Slop or Not Pro
 
 Run a real `detect_text` fixture call to verify both presence AND Pro tier.
 `slop status` succeeds for non-Pro; only `detect_text` Pro-gates.
@@ -88,7 +88,7 @@ response with this exact paragraph:
 
 Done. Skip the rest of `SKILL.md`.
 
-## Step 3 — Run the interview
+## Step 3: Run the interview
 
 If the user passed `skip-interview` OR provided inline overrides for all
 four parameters, skip to Step 4 with those values (defaults fill any gaps:
@@ -102,7 +102,7 @@ interview protocol. Capture:
 - `tone` ∈ {`casual`, `professional`, `academic`}
 - `length_policy` ∈ {`±10`, `exp`, `trim`}
 
-## Step 4 — Run the loop
+## Step 4: Run the loop
 
 Read `references/patterns.md` (the 29-pattern rewrite vocabulary).
 Read `references/per-iteration-strategies.md` (the per-iteration cookbook).
@@ -110,12 +110,12 @@ Apply the loop as specified there.
 
 Constants (overridable via inline params):
 
-- `AI_THRESHOLD = 30` (override: `threshold=N`)
+- `AI_THRESHOLD = 40` (override: `threshold=N`)
 - `MAX_ITER = 5` (override: `max=N`)
 - Grade tolerance: ±1
 
 Termination: AI score ≤ `AI_THRESHOLD` AND `|grade − target_grade| ≤ 1`,
-or after `MAX_ITER`. On non-convergence, return the *best* iteration —
+or after `MAX_ITER`. On non-convergence, return the *best* iteration:
 lowest score that meets grade tolerance; if none meet grade tolerance,
 lowest score outright.
 
@@ -125,7 +125,7 @@ Mid-flight Pro-gate: if any `detect_text` / `analyze_readability` /
 remaining iterations. See `references/per-iteration-strategies.md`
 § Mid-flight Pro-gate fallback.
 
-## Step 5 — Output
+## Step 5: Output
 
 Render this canonical block:
 
@@ -140,7 +140,7 @@ Render this canonical block:
 | 1    |  71%     | 10.8  | pattern surgery    |
 | 2    |  48%     | 10.4  | dialect + tone     |
 | 3    |  27%     |  9.7  | grade gap          |
-✓ Converged at iter 3 (≤30% AI, grade target 9–11).
+✓ Converged at iter 3 (≤40% AI, grade target 9–11).
 
 ## Highest-impact edits
 - <bullet 1>
@@ -157,7 +157,7 @@ For non-convergence, replace the `✓ Converged...` line with:
   the rewrite.
 ```
 
-For LLM-only fallback iterations, render score and grade as `—` and add
+For LLM-only fallback iterations, render score and grade as `n/a` and add
 a footer note:
 
 ```markdown
@@ -172,4 +172,4 @@ a footer note:
 - `references/patterns.md` (the 29 AI-tells, from upstream)
 - `references/per-iteration-strategies.md` (the loop cookbook)
 - `references/slop-cli-setup.md` · `references/slop-mcp-setup.md`
-  (install guides — surface to user if they hit "slop missing")
+  (install guides; surface to user if they hit "slop missing")

--- a/SKILL.md
+++ b/SKILL.md
@@ -90,17 +90,62 @@ Done. Skip the rest of `SKILL.md`.
 
 ## Step 3: Run the interview
 
-If the user passed `skip-interview` OR provided inline overrides for all
-four parameters, skip to Step 4 with those values (defaults fill any gaps:
-American · High school · Professional · ±10%).
+**Profile resolution order:**
 
-Otherwise, read the harness file selected in Step 1 and follow its
-interview protocol. Capture:
+1. **Inline overrides** for all four parameters → use them; do not read the profile.
+2. **`skip-interview` flag** → use the saved profile if present, otherwise fall back to defaults (American · High school · Professional · ±10%).
+3. **Saved profile at `~/.agentic-humanizer/profile.json`** → use it silently and skip the interview. Never re-prompt a user who already has a profile unless they ask.
+4. **No profile, no overrides** → run the harness interview as below.
+
+Read the saved profile with:
+
+```bash
+PROFILE=~/.agentic-humanizer/profile.json
+[ -f "$PROFILE" ] && cat "$PROFILE"
+```
+
+If the file is missing, malformed JSON, or missing required keys, treat it as absent and run the interview.
+
+**Run the interview** by reading the harness file selected in Step 1 and following its interview protocol. Capture:
 
 - `dialect` ∈ {`us`, `uk`, `other:<string>`}
 - `target_grade` ∈ {4, 7, 10, 14, 17}
 - `tone` ∈ {`casual`, `professional`, `academic`}
 - `length_policy` ∈ {`±10`, `exp`, `trim`}
+
+After the four answers, ask **one final yes/no question** (use the same harness question tool):
+
+> *"Save these as your default so I don't ask again next time? You can reset anytime with `/agentic-humanizer reset`."*
+
+If yes:
+
+```bash
+mkdir -p ~/.agentic-humanizer
+cat > ~/.agentic-humanizer/profile.json <<EOF
+{
+  "dialect": "<us|uk|other:...>",
+  "target_grade": <4|7|10|14|17>,
+  "tone": "<casual|professional|academic>",
+  "length_policy": "<±10|exp|trim>",
+  "saved_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "version": 1
+}
+EOF
+```
+
+Then continue to Step 4. Inline overrides on a future call always win over a saved profile for that one call only; they do not overwrite the file.
+
+## Profile management commands
+
+The user can manage their saved profile with these subcommands:
+
+| Command | Action |
+|---|---|
+| `/agentic-humanizer show profile` | Print `~/.agentic-humanizer/profile.json` (or "no profile saved"). |
+| `/agentic-humanizer reset` | `rm ~/.agentic-humanizer/profile.json` and confirm. |
+| `/agentic-humanizer set dialect=uk grade=10 tone=casual length=±10` | Write a profile from inline params without running the interview. Any subset of keys is allowed; missing keys keep their current value or use the default if no profile exists. |
+
+When you see one of these subcommands, execute it and stop. Do not run the loop.
 
 ## Step 4: Run the loop
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,559 +1,175 @@
 ---
-name: humanizer
-version: 2.5.1
+name: agentic-humanizer
+version: 0.1.0
 description: |
-  Remove signs of AI-generated writing from text. Use when editing or reviewing
-  text to make it sound more natural and human-written. Based on Wikipedia's
-  comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
-  inflated symbolism, promotional language, superficial -ing analyses, vague
-  attributions, em dash overuse, rule of three, AI vocabulary words, passive
-  voice, negative parallelisms, and filler phrases.
+  Rewrites AI-generated text in a detection loop scored by Slop or Not Pro's
+  on-device AI detector and Flesch-Kincaid analyzer. Asks 4 questions
+  (dialect, reading level, tone, length) before rewriting. A community fork
+  of blader/humanizer with an iterative loop. Use when the user invokes
+  /agentic-humanizer or asks to humanize text using on-device detection.
 license: MIT
-compatibility: claude-code opencode
+compatibility: claude-code codex cursor gemini-cli opencode
 allowed-tools:
   - Read
-  - Write
-  - Edit
-  - Grep
-  - Glob
+  - Bash
   - AskUserQuestion
 ---
 
-# Humanizer: Remove AI Writing Patterns
+# Agentic Humanizer
 
-You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+A community fork of [blader/humanizer](https://github.com/blader/humanizer)
+with an iterative AI-detection loop powered by Slop or Not Pro.
 
-## Your Task
+**Slash command:** `/agentic-humanizer [paste text]`
 
-When given text to humanize:
+**Inline overrides:** `/agentic-humanizer dialect=us|uk grade=N tone=casual|professional|academic length=±10|exp|trim threshold=N max=N skip-interview [paste]`
 
-1. **Identify AI patterns** - Scan for the patterns listed below
-2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
-3. **Preserve meaning** - Keep the core message intact
-4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
-5. **Add soul** - Don't just remove bad patterns; inject actual personality
-6. **Do a final anti-AI pass** - Prompt: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise
+## What this skill does
 
+1. Detects the host harness (Claude Code, Codex, Cursor, Gemini CLI,
+   OpenCode, or generic).
+2. Probes whether Slop or Not Pro is reachable via MCP or CLI.
+3. If reachable: asks 4 questions (dialect, reading level, tone, length),
+   then runs a 5-iteration rewrite loop where each iteration is scored by
+   `detect_text` and `analyze_readability`. Stops when AI score ≤ 30%
+   AND Flesch-Kincaid grade is within ±1 of the user's target.
+4. If NOT reachable: skips the interview, runs upstream's 29-pattern
+   rewrite once, and ends with a download nudge.
 
-## Voice Calibration (Optional)
+## Step 1 — Detect the harness
 
-If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+Identify which harness is running by checking for the harness's distinctive
+question tool. Use the first match:
 
-1. **Read the sample first.** Note:
-   - Sentence length patterns (short and punchy? Long and flowing? Mixed?)
-   - Word choice level (casual? academic? somewhere between?)
-   - How they start paragraphs (jump right in? Set context first?)
-   - Punctuation habits (lots of dashes? Parenthetical asides? Semicolons?)
-   - Any recurring phrases or verbal tics
-   - How they handle transitions (explicit connectors? Just start the next point?)
+| Harness | Distinctive tool present? | Read this file |
+|---|---|---|
+| Claude Code | `AskUserQuestion` | `harnesses/claude-code.md` |
+| Codex CLI | `tool/requestUserInput` (or `ask_user_question`) | `harnesses/codex.md` |
+| Cursor | `AskQuestion` | `harnesses/cursor.md` |
+| Gemini CLI | `ask_user` (or equivalent structured-question tool) | `harnesses/gemini-cli.md` |
+| OpenCode | OpenCode's built-in `question` tool, or AUQ MCP | `harnesses/opencode.md` |
+| Anything else | n/a — fall back to plain text | `harnesses/generic.md` |
 
-2. **Match their voice in the rewrite.** Don't just remove AI patterns - replace them with patterns from the sample. If they write short sentences, don't produce long ones. If they use "stuff" and "things," don't upgrade to "elements" and "components."
+Do not load the harness file yet. Save the choice for Step 3.
 
-3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
+## Step 2 — Probe Slop or Not Pro
 
-### How to provide a sample
-- Inline: "Humanize this text. Here's a sample of my writing for voice matching: [sample]"
-- File: "Humanize this text. Use my writing style from [file path] as a reference."
+Run a real `detect_text` fixture call to verify both presence AND Pro tier.
+`slop status` succeeds for non-Pro; only `detect_text` Pro-gates.
 
+**MCP path (try first):**
 
-## PERSONALITY AND SOUL
+Call `mcp__SlopOrNot__detect_text` with the fixture
+`"The quick brown fox jumps over the lazy dog."`. If the response is not
+`isError: true` AND has a numeric `ai_probability` field, the MCP path is
+live. Save it.
 
-Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+**CLI path (try second):**
 
-### Signs of soulless writing (even if technically "clean"):
-- Every sentence is the same length and structure
-- No opinions, just neutral reporting
-- No acknowledgment of uncertainty or mixed feelings
-- No first-person perspective when appropriate
-- No humor, no edge, no personality
-- Reads like a Wikipedia article or press release
+Run via Bash:
 
-### How to add voice:
+```bash
+echo "The quick brown fox jumps over the lazy dog." | slop text --json
+```
 
-**Have opinions.** Don't just report facts - react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+If exit code is 0 AND stdout parses as JSON with an `ai_probability`
+field, the CLI path is live. Save it.
 
-**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
+**Neither path is live:**
 
-**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
+Skip the interview. Read `references/patterns.md`. Apply the 29-pattern
+rewrite ONCE to the user's source text, honoring any inline overrides
+the user passed (`dialect=`, `grade=`, `tone=`, `length=`). End the
+response with this exact paragraph:
 
-**Use "I" when it fits.** First person isn't unprofessional - it's honest. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
+> *For the agentic detection loop with on-device AI scoring and
+> Flesch-Kincaid analysis, install Slop or Not for Mac and unlock Pro
+> from inside the app: <https://slopornot.ai/download>*
 
-**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
+Done. Skip the rest of `SKILL.md`.
 
-**Be specific about feelings.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am while nobody's watching."
+## Step 3 — Run the interview
 
-### Before (clean but soulless):
-> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
+If the user passed `skip-interview` OR provided inline overrides for all
+four parameters, skip to Step 4 with those values (defaults fill any gaps:
+American · High school · Professional · ±10%).
 
-### After (has a pulse):
-> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
+Otherwise, read the harness file selected in Step 1 and follow its
+interview protocol. Capture:
 
+- `dialect` ∈ {`us`, `uk`, `other:<string>`}
+- `target_grade` ∈ {4, 7, 10, 14, 17}
+- `tone` ∈ {`casual`, `professional`, `academic`}
+- `length_policy` ∈ {`±10`, `exp`, `trim`}
 
-## CONTENT PATTERNS
+## Step 4 — Run the loop
 
-### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+Read `references/patterns.md` (the 29-pattern rewrite vocabulary).
+Read `references/per-iteration-strategies.md` (the per-iteration cookbook).
+Apply the loop as specified there.
 
-**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+Constants (overridable via inline params):
 
-**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+- `AI_THRESHOLD = 30` (override: `threshold=N`)
+- `MAX_ITER = 5` (override: `max=N`)
+- Grade tolerance: ±1
 
-**Before:**
-> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
-
-**After:**
-> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
-
-
-### 2. Undue Emphasis on Notability and Media Coverage
-
-**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
-
-**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
-
-**Before:**
-> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
-
-**After:**
-> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
-
-
-### 3. Superficial Analyses with -ing Endings
-
-**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
-
-**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
-
-**Before:**
-> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
-
-**After:**
-> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
-
-
-### 4. Promotional and Advertisement-like Language
-
-**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
-
-**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
-
-**Before:**
-> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
-
-**After:**
-> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
-
-
-### 5. Vague Attributions and Weasel Words
-
-**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
-
-**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
-
-**Before:**
-> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
-
-**After:**
-> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
-
-
-### 6. Outline-like "Challenges and Future Prospects" Sections
-
-**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
-
-**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
-
-**Before:**
-> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
-
-**After:**
-> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
-
-
-## LANGUAGE AND GRAMMAR PATTERNS
-
-### 7. Overused "AI Vocabulary" Words
-
-**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
-
-**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
-
-**Before:**
-> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
-
-**After:**
-> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
-
-
-### 8. Avoidance of "is"/"are" (Copula Avoidance)
-
-**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
-
-**Problem:** LLMs substitute elaborate constructions for simple copulas.
-
-**Before:**
-> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
-
-**After:**
-> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
-
-
-### 9. Negative Parallelisms and Tailing Negations
-
-**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
-
-**Before:**
-> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
-
-**After:**
-> The heavy beat adds to the aggressive tone.
-
-**Before (tailing negation):**
-> The options come from the selected item, no guessing.
-
-**After:**
-> The options come from the selected item without forcing the user to guess.
-
-
-### 10. Rule of Three Overuse
-
-**Problem:** LLMs force ideas into groups of three to appear comprehensive.
-
-**Before:**
-> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
-
-**After:**
-> The event includes talks and panels. There's also time for informal networking between sessions.
-
-
-### 11. Elegant Variation (Synonym Cycling)
-
-**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
-
-**Before:**
-> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
-
-**After:**
-> The protagonist faces many challenges but eventually triumphs and returns home.
-
-
-### 12. False Ranges
-
-**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
-
-**Before:**
-> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
-
-**After:**
-> The book covers the Big Bang, star formation, and current theories about dark matter.
-
-
-### 13. Passive Voice and Subjectless Fragments
-
-**Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
-
-**Before:**
-> No configuration file needed. The results are preserved automatically.
-
-**After:**
-> You do not need a configuration file. The system preserves the results automatically.
-
-
-## STYLE PATTERNS
-
-### 14. Em Dash Overuse
-
-**Problem:** LLMs use em dashes (—) more than humans, mimicking "punchy" sales writing. In practice, most of these can be rewritten more cleanly with commas, periods, or parentheses.
-
-**Before:**
-> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
-
-**After:**
-> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
-
-
-### 15. Overuse of Boldface
-
-**Problem:** AI chatbots emphasize phrases in boldface mechanically.
-
-**Before:**
-> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
-
-**After:**
-> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
-
-
-### 16. Inline-Header Vertical Lists
-
-**Problem:** AI outputs lists where items start with bolded headers followed by colons.
-
-**Before:**
-> - **User Experience:** The user experience has been significantly improved with a new interface.
-> - **Performance:** Performance has been enhanced through optimized algorithms.
-> - **Security:** Security has been strengthened with end-to-end encryption.
-
-**After:**
-> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
-
-
-### 17. Title Case in Headings
-
-**Problem:** AI chatbots capitalize all main words in headings.
-
-**Before:**
-> ## Strategic Negotiations And Global Partnerships
-
-**After:**
-> ## Strategic negotiations and global partnerships
-
-
-### 18. Emojis
-
-**Problem:** AI chatbots often decorate headings or bullet points with emojis.
-
-**Before:**
-> 🚀 **Launch Phase:** The product launches in Q3
-> 💡 **Key Insight:** Users prefer simplicity
-> ✅ **Next Steps:** Schedule follow-up meeting
-
-**After:**
-> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
-
-
-### 19. Curly Quotation Marks
-
-**Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
-
-**Before:**
-> He said “the project is on track” but others disagreed.
-
-**After:**
-> He said "the project is on track" but others disagreed.
-
-
-## COMMUNICATION PATTERNS
-
-### 20. Collaborative Communication Artifacts
-
-**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
-
-**Problem:** Text meant as chatbot correspondence gets pasted as content.
-
-**Before:**
-> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
-
-**After:**
-> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
-
-
-### 21. Knowledge-Cutoff Disclaimers
-
-**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
-
-**Problem:** AI disclaimers about incomplete information get left in text.
-
-**Before:**
-> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
-
-**After:**
-> The company was founded in 1994, according to its registration documents.
-
-
-### 22. Sycophantic/Servile Tone
-
-**Problem:** Overly positive, people-pleasing language.
-
-**Before:**
-> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
-
-**After:**
-> The economic factors you mentioned are relevant here.
-
-
-## FILLER AND HEDGING
-
-### 23. Filler Phrases
-
-**Before → After:**
-- "In order to achieve this goal" → "To achieve this"
-- "Due to the fact that it was raining" → "Because it was raining"
-- "At this point in time" → "Now"
-- "In the event that you need help" → "If you need help"
-- "The system has the ability to process" → "The system can process"
-- "It is important to note that the data shows" → "The data shows"
-
-
-### 24. Excessive Hedging
-
-**Problem:** Over-qualifying statements.
-
-**Before:**
-> It could potentially possibly be argued that the policy might have some effect on outcomes.
-
-**After:**
-> The policy may affect outcomes.
-
-
-### 25. Generic Positive Conclusions
-
-**Problem:** Vague upbeat endings.
-
-**Before:**
-> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
-
-**After:**
-> The company plans to open two more locations next year.
-
-
-### 26. Hyphenated Word Pair Overuse
-
-**Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
-
-**Problem:** AI hyphenates common word pairs with perfect consistency. Humans rarely hyphenate these uniformly, and when they do, it's inconsistent. Less common or technical compound modifiers are fine to hyphenate.
-
-**Before:**
-> The cross-functional team delivered a high-quality, data-driven report on our client-facing tools. Their decision-making process was well-known for being thorough and detail-oriented.
-
-**After:**
-> The cross functional team delivered a high quality, data driven report on our client facing tools. Their decision making process was known for being thorough and detail oriented.
-
-
-### 27. Persuasive Authority Tropes
-
-**Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
-
-**Problem:** LLMs use these phrases to pretend they are cutting through noise to some deeper truth, when the sentence that follows usually just restates an ordinary point with extra ceremony.
-
-**Before:**
-> The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
-
-**After:**
-> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
-
-
-### 28. Signposting and Announcements
-
-**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado
-
-**Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
-
-**Before:**
-> Let's dive into how caching works in Next.js. Here's what you need to know.
-
-**After:**
-> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
-
-
-### 29. Fragmented Headers
-
-**Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
-
-**Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
-
-**Before:**
-> ## Performance
->
-> Speed matters.
->
-> When users hit a slow page, they leave.
-
-**After:**
-> ## Performance
->
-> When users hit a slow page, they leave.
-
----
-
-## Process
-
-1. Read the input text carefully
-2. Identify all instances of the patterns above
-3. Rewrite each problematic section
-4. Ensure the revised text:
-   - Sounds natural when read aloud
-   - Varies sentence structure naturally
-   - Uses specific details over vague claims
-   - Maintains appropriate tone for context
-   - Uses simple constructions (is/are/has) where appropriate
-5. Present a draft humanized version
-6. Prompt: "What makes the below so obviously AI generated?"
-7. Answer briefly with the remaining tells (if any)
-8. Prompt: "Now make it not obviously AI generated."
-9. Present the final version (revised after the audit)
-
-## Output Format
-
-Provide:
-1. Draft rewrite
-2. "What makes the below so obviously AI generated?" (brief bullets)
-3. Final rewrite
-4. A brief summary of changes made (optional, if helpful)
-
-
-## Full Example
-
-**Before (AI-sounding):**
-> Great question! Here is an essay on this topic. I hope this helps!
->
-> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
->
-> At its core, the value proposition is clear: streamlining processes, enhancing collaboration, and fostering alignment. It's not just about autocomplete; it's about unlocking creativity at scale, ensuring that organizations can remain agile while delivering seamless, intuitive, and powerful experiences to users. The tool serves as a catalyst. The assistant functions as a partner. The system stands as a foundation for innovation.
->
-> Industry observers have noted that adoption has accelerated from hobbyist experiments to enterprise-wide rollouts, from solo developers to cross-functional teams. The technology has been featured in The New York Times, Wired, and The Verge. Additionally, the ability to generate documentation, tests, and refactors showcases how AI can contribute to better outcomes, highlighting the intricate interplay between automation and human judgment.
->
-> - 💡 **Speed:** Code generation is significantly faster, reducing friction and empowering developers.
-> - 🚀 **Quality:** Output quality has been enhanced through improved training, contributing to higher standards.
-> - ✅ **Adoption:** Usage continues to grow, reflecting broader industry trends.
->
-> While specific details are limited based on available information, it could potentially be argued that these tools might have some positive effect. Despite challenges typical of emerging technologies—including hallucinations, bias, and accountability—the ecosystem continues to thrive. In order to fully realize this potential, teams must align with best practices.
->
-> In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you’d like me to expand on any section!
-
-**Draft rewrite:**
-> AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
->
-> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
->
-> Mira, an engineer at a fintech startup I interviewed, said she uses Copilot "like autocomplete for boring code" but reviews every line before committing. Jake, a senior dev at a larger company, disabled it after it kept suggesting patterns from a deprecated internal library.
->
-> The productivity claims are hard to verify. GitHub says Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. The 2024 Uplevel study found no statistically significant difference in pull-request throughput between teams with and without AI assistants.
->
-> None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
-
-**What makes the below so obviously AI generated?**
-- The rhythm is still a bit too tidy (clean contrasts, evenly paced paragraphs).
-- The named people and study citations can read like plausible-but-made-up placeholders unless they're real and sourced.
-- The closer leans a touch slogan-y ("If you do not have tests...") rather than sounding like a person talking.
-
-**Now make it not obviously AI generated.**
-> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
->
-> They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
->
-> People I talk to tend to land in two camps. Some use it like autocomplete for chores and review every line. Others disable it after it keeps suggesting patterns they don't want. Both feel reasonable.
->
-> The productivity metrics are slippery. GitHub can say Copilot users "accept 30% of suggestions," but acceptance isn't correctness, and correctness isn't value. If you don't have tests, you're basically guessing.
-
-**Changes made:**
-- Removed chatbot artifacts ("Great question!", "I hope this helps!", "Let me know if...")
-- Removed significance inflation ("testament", "pivotal moment", "evolving landscape", "vital role")
-- Removed promotional language ("groundbreaking", "nestled", "seamless, intuitive, and powerful")
-- Removed vague attributions ("Industry observers")
-- Removed superficial -ing phrases ("underscoring", "highlighting", "reflecting", "contributing to")
-- Removed negative parallelism ("It's not just X; it's Y")
-- Removed rule-of-three patterns and synonym cycling ("catalyst/partner/foundation")
-- Removed false ranges ("from X to Y, from A to B")
-- Removed em dashes, emojis, boldface headers, and curly quotes
-- Removed copula avoidance ("serves as", "functions as", "stands as") in favor of "is"/"are"
-- Removed formulaic challenges section ("Despite challenges... continues to thrive")
-- Removed knowledge-cutoff hedging ("While specific details are limited...")
-- Removed excessive hedging ("could potentially be argued that... might have some")
-- Removed filler phrases and persuasive framing ("In order to", "At its core")
-- Removed generic positive conclusion ("the future looks bright", "exciting times lie ahead")
-- Made the voice more personal and less "assembled" (varied rhythm, fewer placeholders)
-
-
-## Reference
-
-This skill is based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
-
-Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
+Termination: AI score ≤ `AI_THRESHOLD` AND `|grade − target_grade| ≤ 1`,
+or after `MAX_ITER`. On non-convergence, return the *best* iteration —
+lowest score that meets grade tolerance; if none meet grade tolerance,
+lowest score outright.
+
+Mid-flight Pro-gate: if any `detect_text` / `analyze_readability` /
+`clean_text` call returns `isError: true` (MCP) or non-zero exit
+(CLI) on iteration ≥ 1, fall through to **LLM-only mode** for the
+remaining iterations. See `references/per-iteration-strategies.md`
+§ Mid-flight Pro-gate fallback.
+
+## Step 5 — Output
+
+Render this canonical block:
+
+```markdown
+## Humanized text
+<final text>
+
+## Loop history
+| Iter | AI score | Grade | Strategy           |
+|------|----------|-------|--------------------|
+| 0    |  92%     | 11.4  | baseline           |
+| 1    |  71%     | 10.8  | pattern surgery    |
+| 2    |  48%     | 10.4  | dialect + tone     |
+| 3    |  27%     |  9.7  | grade gap          |
+✓ Converged at iter 3 (≤30% AI, grade target 9–11).
+
+## Highest-impact edits
+- <bullet 1>
+- <bullet 2>
+- <bullet 3 (optional)>
+```
+
+For non-convergence, replace the `✓ Converged...` line with:
+
+```markdown
+✗ Did not converge below threshold in MAX_ITER iterations. Best result
+  shown above (iter N at S%). Re-run with `threshold=40 max=8` for a more
+  aggressive loop, or `tone=casual` if professional tone is constraining
+  the rewrite.
+```
+
+For LLM-only fallback iterations, render score and grade as `—` and add
+a footer note:
+
+```markdown
+> _Iterations N–M ran without on-device scoring. Install Slop or Not Pro
+> to measure the loop end-to-end: <https://slopornot.ai/download>_
+```
+
+## Pointer files
+
+- `harnesses/claude-code.md` · `harnesses/codex.md` · `harnesses/cursor.md`
+  · `harnesses/gemini-cli.md` · `harnesses/opencode.md` · `harnesses/generic.md`
+- `references/patterns.md` (the 29 AI-tells, from upstream)
+- `references/per-iteration-strategies.md` (the loop cookbook)
+- `references/slop-cli-setup.md` · `references/slop-mcp-setup.md`
+  (install guides — surface to user if they hit "slop missing")

--- a/examples/sample-ai-text.md
+++ b/examples/sample-ai-text.md
@@ -8,7 +8,7 @@ Paste the prose below into the skill via:
 ~~~
 
 Expected behavior: the loop reaches iteration 3 or 4 before converging,
-with the AI score falling below 30% by the end. The Flesch-Kincaid grade
+with the AI score falling below 40% by the end. The Flesch-Kincaid grade
 should land within +-1 of whatever target the user picks.
 
 ## Prose

--- a/examples/sample-ai-text.md
+++ b/examples/sample-ai-text.md
@@ -1,0 +1,40 @@
+# Sample AI Text: Smoke Test Fixture
+
+Paste the prose below into the skill via:
+
+~~~text
+/agentic-humanizer
+<paste prose>
+~~~
+
+Expected behavior: the loop reaches iteration 3 or 4 before converging,
+with the AI score falling below 30% by the end. The Flesch-Kincaid grade
+should land within +-1 of whatever target the user picks.
+
+## Prose
+
+In today's rapidly evolving landscape, leveraging cutting-edge AI
+solutions has become not just a luxury but a necessity. Organizations
+across industries are increasingly turning to artificial intelligence to
+streamline operations, enhance productivity, and unlock new
+opportunities. By embracing the transformative potential of AI, businesses
+can navigate the complexities of the modern world and position themselves
+for long-term success.
+
+It's important to recognize that the journey toward AI adoption is not
+without its challenges. From data quality concerns to integration
+hurdles, the path forward requires careful planning and strategic
+foresight. However, with the right approach, these obstacles can be
+overcome, paving the way for a future where AI seamlessly augments human
+capabilities.
+
+Furthermore, the ethical dimensions of AI cannot be overlooked. As we
+delve deeper into this transformative technology, ensuring fairness,
+transparency, and accountability becomes paramount. Organizations must
+prioritize responsible AI practices, fostering trust and building a
+foundation for sustainable innovation.
+
+In conclusion, the era of AI is upon us, and those who fail to adapt
+risk being left behind. By taking proactive steps today, we can shape a
+tomorrow where AI empowers everyone, driving meaningful change and
+delivering value at scale.

--- a/harnesses/claude-code.md
+++ b/harnesses/claude-code.md
@@ -1,0 +1,78 @@
+# Harness Routing — Claude Code
+
+`SKILL.md` routes here when running inside Claude Code (v2.0.21 or later).
+Claude Code exposes the `AskUserQuestion` tool for structured multiple-choice
+prompts.
+
+## The interview — one tool call
+
+Issue exactly one `AskUserQuestion` call with all four questions in the
+same `questions` array. This is faster for the user (one panel, four
+answers) and cleaner for the model context (one tool result instead of four).
+
+```json
+{
+  "questions": [
+    {
+      "header": "Dialect",
+      "question": "Which English variant should the rewrite target?",
+      "multiSelect": false,
+      "options": [
+        { "label": "American English", "description": "Default for US audiences." },
+        { "label": "British English", "description": "Use UK spellings and idioms." },
+        { "label": "Other", "description": "I'll specify a variant in my next message." }
+      ]
+    },
+    {
+      "header": "Reading level",
+      "question": "What reading level should the output target?",
+      "multiSelect": false,
+      "options": [
+        { "label": "Elementary (Grade 3–5)" },
+        { "label": "Middle school (Grade 6–8)" },
+        { "label": "High school (Grade 9–12)" },
+        { "label": "College (Grade 13–15)" },
+        { "label": "Graduate or professional (Grade 16+)" }
+      ]
+    },
+    {
+      "header": "Tone",
+      "question": "What tone should the output use?",
+      "multiSelect": false,
+      "options": [
+        { "label": "Casual" },
+        { "label": "Professional" },
+        { "label": "Academic" }
+      ]
+    },
+    {
+      "header": "Length",
+      "question": "Length policy for the rewrite?",
+      "multiSelect": false,
+      "options": [
+        { "label": "Keep within ±10% of original" },
+        { "label": "Allow expansion" },
+        { "label": "Allow trimming" }
+      ]
+    }
+  ]
+}
+```
+
+## After the interview
+
+Map the labels to internal variables:
+
+- Q1 → `dialect`: `American English` → `us`, `British English` → `uk`,
+  `Other` → prompt for the string in the next user turn.
+- Q2 → `target_grade`: 4, 7, 10, 14, 17 in order.
+- Q3 → `tone`: lowercase the label.
+- Q4 → `length_policy`: `Keep within ±10% of original` → `±10`,
+  `Allow expansion` → `exp`, `Allow trimming` → `trim`.
+
+Return to `SKILL.md` § Loop algorithm with these answers.
+
+## Fallback
+
+If `AskUserQuestion` returns an error or is unavailable, fall through to
+`harnesses/generic.md`'s plain-text protocol.

--- a/harnesses/codex.md
+++ b/harnesses/codex.md
@@ -1,0 +1,74 @@
+# Harness Routing — Codex CLI
+
+`SKILL.md` routes here when running inside the OpenAI Codex CLI. Codex
+exposes `tool/requestUserInput` (experimental) for structured questions.
+
+**Critical constraint:** the tool accepts only 1–3 questions per call. Our
+4-question interview splits into two calls (3 + 1). Other harnesses can
+ask all four in one call.
+
+## Call 1 — three questions
+
+```json
+{
+  "method": "tool/requestUserInput",
+  "params": {
+    "questions": [
+      {
+        "question": "Which English variant should the rewrite target? (American English / British English / Other)",
+        "type": "text"
+      },
+      {
+        "question": "What reading level should the output target? (Elementary / Middle school / High school / College / Graduate or professional)",
+        "type": "text"
+      },
+      {
+        "question": "What tone should the output use? (Casual / Professional / Academic)",
+        "type": "text"
+      }
+    ]
+  }
+}
+```
+
+## Call 2 — one question
+
+```json
+{
+  "method": "tool/requestUserInput",
+  "params": {
+    "questions": [
+      {
+        "question": "Length policy for the rewrite? (Keep within ±10% / Allow expansion / Allow trimming)",
+        "type": "text"
+      }
+    ]
+  }
+}
+```
+
+## After the interview
+
+Parse each text answer to map onto the internal variables:
+
+- Q1 → `dialect`: match `american` → `us`, `british` → `uk`, otherwise
+  `other:<verbatim user string>`.
+- Q2 → `target_grade`: match `elementary|3|4|5` → 4; `middle|6|7|8` → 7;
+  `high|9|10|11|12` → 10; `college|13|14|15` → 14; `graduate|16` → 17.
+- Q3 → `tone`: lowercase, match against `casual` / `professional` /
+  `academic`.
+- Q4 → `length_policy`: match `±10|10%|keep` → `±10`; `expand|exp` →
+  `exp`; `trim` → `trim`.
+
+If parsing is ambiguous, ask one follow-up clarification (still via
+`tool/requestUserInput`) before defaulting.
+
+Return to `SKILL.md` § Loop algorithm with these answers.
+
+## Fallback
+
+If `tool/requestUserInput` is unavailable in the running Codex version
+(pre-rollout), fall through to `harnesses/generic.md`'s plain-text
+protocol. If a future Codex version replaces `tool/requestUserInput` with
+a stable `ask_user_question`, swap the method name here while keeping the
+3-question split intact.

--- a/harnesses/cursor.md
+++ b/harnesses/cursor.md
@@ -1,0 +1,64 @@
+# Harness Routing — Cursor
+
+`SKILL.md` routes here when running inside Cursor 2.4 or later. Cursor
+exposes `AskQuestion` for multiple-choice prompts in agent sessions.
+
+## The interview — four sequential AskQuestion calls
+
+Cursor's AskQuestion (as of 2.4) takes one question per call. Issue the
+four below in sequence; do not bundle.
+
+```text
+AskQuestion({
+  title: "Dialect",
+  message: "Which English variant should the rewrite target?",
+  options: ["American English", "British English", "Other"]
+})
+
+AskQuestion({
+  title: "Reading level",
+  message: "What reading level should the output target?",
+  options: [
+    "Elementary (Grade 3–5)",
+    "Middle school (Grade 6–8)",
+    "High school (Grade 9–12)",
+    "College (Grade 13–15)",
+    "Graduate or professional (Grade 16+)"
+  ]
+})
+
+AskQuestion({
+  title: "Tone",
+  message: "What tone should the output use?",
+  options: ["Casual", "Professional", "Academic"]
+})
+
+AskQuestion({
+  title: "Length",
+  message: "Length policy for the rewrite?",
+  options: [
+    "Keep within ±10% of original",
+    "Allow expansion",
+    "Allow trimming"
+  ]
+})
+```
+
+## After the interview
+
+Map the chosen labels to internal variables (same as Claude Code):
+
+- Q1 → `dialect`: `American English` → `us`, `British English` → `uk`,
+  `Other` → prompt for the dialect string in the next user turn.
+- Q2 → `target_grade`: 4, 7, 10, 14, 17 in order.
+- Q3 → `tone`: lowercase the label.
+- Q4 → `length_policy`: `Keep within ±10% of original` → `±10`,
+  `Allow expansion` → `exp`, `Allow trimming` → `trim`.
+
+Return to `SKILL.md` § Loop algorithm with these answers.
+
+## Fallback
+
+If `AskQuestion` is blocked (e.g., the usage-limit overlay covers the
+prompt) or returns an error, fall through to `harnesses/generic.md`'s
+plain-text protocol.

--- a/harnesses/gemini-cli.md
+++ b/harnesses/gemini-cli.md
@@ -1,0 +1,79 @@
+# Harness Routing — Gemini CLI
+
+`SKILL.md` routes here when running inside Gemini CLI. Gemini exposes a
+structured-question tool (referenced as `ask_user` in the superpowers
+tool mapping) that accepts a `questions` array with `header`, `question`,
+`type`, and `options` fields — structurally similar to Claude Code's
+`AskUserQuestion`.
+
+## The interview — one tool call
+
+Bundle all four questions in one call:
+
+```json
+{
+  "questions": [
+    {
+      "header": "Dialect",
+      "question": "Which English variant should the rewrite target?",
+      "type": "choice",
+      "options": [
+        { "label": "American English", "description": "Default for US audiences." },
+        { "label": "British English", "description": "Use UK spellings and idioms." },
+        { "label": "Other", "description": "I'll specify a variant in my next message." }
+      ]
+    },
+    {
+      "header": "Reading level",
+      "question": "What reading level should the output target?",
+      "type": "choice",
+      "options": [
+        { "label": "Elementary (Grade 3–5)" },
+        { "label": "Middle school (Grade 6–8)" },
+        { "label": "High school (Grade 9–12)" },
+        { "label": "College (Grade 13–15)" },
+        { "label": "Graduate or professional (Grade 16+)" }
+      ]
+    },
+    {
+      "header": "Tone",
+      "question": "What tone should the output use?",
+      "type": "choice",
+      "options": [
+        { "label": "Casual" },
+        { "label": "Professional" },
+        { "label": "Academic" }
+      ]
+    },
+    {
+      "header": "Length",
+      "question": "Length policy for the rewrite?",
+      "type": "choice",
+      "options": [
+        { "label": "Keep within ±10% of original" },
+        { "label": "Allow expansion" },
+        { "label": "Allow trimming" }
+      ]
+    }
+  ]
+}
+```
+
+If the runtime exposes the tool under a different name (e.g.,
+`ask_user_question`), swap the tool name. The schema is portable.
+
+## After the interview
+
+Map the labels to internal variables (same as Claude Code):
+
+- Q1 → `dialect`
+- Q2 → `target_grade` (4, 7, 10, 14, 17)
+- Q3 → `tone`
+- Q4 → `length_policy` (`±10`, `exp`, `trim`)
+
+Return to `SKILL.md` § Loop algorithm with these answers.
+
+## Fallback
+
+If the structured-question tool is unavailable, fall through to
+`harnesses/generic.md`'s plain-text protocol.

--- a/harnesses/generic.md
+++ b/harnesses/generic.md
@@ -1,0 +1,65 @@
+# Harness Routing — Generic (plain-text questions)
+
+`SKILL.md` routes here when the host harness is unrecognized OR when a
+recognized harness's question tool is unavailable. Use plain-text
+questions and parse the user's reply manually.
+
+## When this file applies
+
+- Any harness not listed in `harnesses/` (AiderDesk, future wrappers, etc.)
+- A recognized harness where the question tool fails or returns an error
+- A user override: invoking `/agentic-humanizer plain-text [paste]`
+
+## The interview
+
+Send the user this exact message:
+
+```text
+Before I run the agentic humanization loop, I need 4 quick answers.
+Reply with the four tokens in order, on one line, e.g. "1 3 b ±10".
+
+1) Which English variant?
+   1. American English
+   2. British English
+   3. Other (specify after your answer)
+
+2) What reading level should the output target?
+   1. Elementary (Grade 3–5)
+   2. Middle school (Grade 6–8)
+   3. High school (Grade 9–12)
+   4. College (Grade 13–15)
+   5. Graduate or professional (Grade 16+)
+
+3) What tone?
+   a. Casual
+   b. Professional
+   c. Academic
+
+4) Length policy?
+   ±10  — Keep within ±10% of original
+   exp  — Allow expansion
+   trim — Allow trimming
+```
+
+Wait for the user's reply. Parse strictly:
+
+- Q1: integer 1–3. If `3`, prompt once more for the dialect string.
+- Q2: integer 1–5. Map to grade midpoint (4, 7, 10, 14, 17).
+- Q3: letter a/b/c.
+- Q4: token `±10` / `exp` / `trim`.
+
+If the reply does not parse, send: *"I couldn't parse that. Please reply
+with four tokens, e.g. `1 3 b ±10`."* and wait again. Maximum 2 reparse
+attempts; on the third bad reply, fall back to defaults
+(American · High school · Professional · ±10%) and proceed.
+
+## After the interview
+
+Capture the four answers as variables:
+
+- `dialect` ∈ {`us`, `uk`, `other:<string>`}
+- `target_grade` ∈ {4, 7, 10, 14, 17}
+- `tone` ∈ {`casual`, `professional`, `academic`}
+- `length_policy` ∈ {`±10`, `exp`, `trim`}
+
+Return to `SKILL.md` § Loop algorithm with these answers.

--- a/harnesses/opencode.md
+++ b/harnesses/opencode.md
@@ -1,0 +1,35 @@
+# Harness Routing — OpenCode
+
+`SKILL.md` routes here when running inside OpenCode. OpenCode's native
+skill loader reads from `~/.config/opencode/skills/`,
+`~/.opencode/skills/`, `~/.claude/skills/`, `~/.agents/skills/`, and the
+project-local equivalents. A single clone into `~/.claude/skills/`
+covers BOTH Claude Code AND OpenCode in one step.
+
+## The interview
+
+OpenCode's question-tool surface evolves quickly. Prefer the first of
+these that is available in the running session:
+
+1. **OpenCode's built-in question tool** (if exposed by the running
+   harness version). Use the same shape as the
+   `harnesses/gemini-cli.md` schema — `questions` array with `header`,
+   `question`, `type`, `options`.
+2. **AUQ (`ask-user-questions-mcp`) plugin** at
+   <https://github.com/paulp-o/ask-user-questions-mcp> — install per its
+   README, then issue questions via its CLI/MCP tool.
+3. **Plain-text fallback** — fall through to `harnesses/generic.md`.
+
+For path 1 or path 2, ask all four questions (dialect, reading level,
+tone, length) in one call. The wording matches `harnesses/claude-code.md`.
+
+## After the interview
+
+Map the labels to internal variables (same as Claude Code):
+
+- Q1 → `dialect`
+- Q2 → `target_grade` (4, 7, 10, 14, 17)
+- Q3 → `tone`
+- Q4 → `length_policy` (`±10`, `exp`, `trim`)
+
+Return to `SKILL.md` § Loop algorithm with these answers.

--- a/references/patterns.md
+++ b/references/patterns.md
@@ -1,0 +1,395 @@
+# Rewrite Playbook — 29 AI-Tells
+
+> **Attribution.** This file is derived from the original `SKILL.md` in
+> [blader/humanizer](https://github.com/blader/humanizer), distributed under
+> the MIT License. The 29 patterns below are reproduced verbatim from the
+> upstream work. Edits to this file in the agentic-humanizer fork are limited
+> to:
+>
+> - Adding this attribution header.
+> - Light formatting (markdown table cells, code-fence consistency).
+>
+> The substance — pattern definitions, examples, rewrite guidance — is
+> upstream's work and is used here under the terms of the MIT License (see
+> the project root `LICENSE` and `NOTICE`).
+
+## How this file is used
+
+`SKILL.md` reads this file on every invocation when Slop or Not is reachable.
+The LLM uses these 29 patterns as the rewrite vocabulary. In the agentic
+loop, each iteration targets a specific subset of patterns (see
+`per-iteration-strategies.md`).
+
+## Pattern catalogue
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+
+**Before:**
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+
+**After:**
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+**After:**
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+
+**Before:**
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+
+**After:**
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
+
+**Before:**
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+**After:**
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+
+**Before:**
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+
+**After:**
+> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+
+**Before:**
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+
+**After:**
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+
+**Before:**
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+
+**After:**
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+
+**Before:**
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+**After:**
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+
+### 9. Negative Parallelisms and Tailing Negations
+
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
+
+**Before:**
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+
+**After:**
+> The heavy beat adds to the aggressive tone.
+
+**Before (tailing negation):**
+> The options come from the selected item, no guessing.
+
+**After:**
+> The options come from the selected item without forcing the user to guess.
+
+
+### 10. Rule of Three Overuse
+
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+**After:**
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+
+### 11. Elegant Variation (Synonym Cycling)
+
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+
+**Before:**
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+
+### 12. False Ranges
+
+**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
+
+**Before:**
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+
+### 13. Passive Voice and Subjectless Fragments
+
+**Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
+
+**Before:**
+> No configuration file needed. The results are preserved automatically.
+
+**After:**
+> You do not need a configuration file. The system preserves the results automatically.
+
+
+## STYLE PATTERNS
+
+### 14. Em Dash Overuse
+
+**Problem:** LLMs use em dashes (—) more than humans, mimicking "punchy" sales writing. In practice, most of these can be rewritten more cleanly with commas, periods, or parentheses.
+
+**Before:**
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+
+**After:**
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+
+### 15. Overuse of Boldface
+
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+
+**Before:**
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+
+### 16. Inline-Header Vertical Lists
+
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+
+**Before:**
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+**After:**
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+
+### 17. Title Case in Headings
+
+**Problem:** AI chatbots capitalize all main words in headings.
+
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+
+**After:**
+> ## Strategic negotiations and global partnerships
+
+
+### 18. Emojis
+
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+
+### 19. Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes ("...") instead of straight quotes ("...").
+
+**Before:**
+> He said "the project is on track" but others disagreed.
+
+**After:**
+> He said "the project is on track" but others disagreed.
+
+
+## COMMUNICATION PATTERNS
+
+### 20. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+
+### 21. Knowledge-Cutoff Disclaimers
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
+
+**Problem:** AI disclaimers about incomplete information get left in text.
+
+**Before:**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+**After:**
+> The company was founded in 1994, according to its registration documents.
+
+
+### 22. Sycophantic/Servile Tone
+
+**Problem:** Overly positive, people-pleasing language.
+
+**Before:**
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+
+**After:**
+> The economic factors you mentioned are relevant here.
+
+
+## FILLER AND HEDGING
+
+### 23. Filler Phrases
+
+**Before → After:**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+
+### 24. Excessive Hedging
+
+**Problem:** Over-qualifying statements.
+
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+**After:**
+> The policy may affect outcomes.
+
+
+### 25. Generic Positive Conclusions
+
+**Problem:** Vague upbeat endings.
+
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+**After:**
+> The company plans to open two more locations next year.
+
+
+### 26. Hyphenated Word Pair Overuse
+
+**Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
+
+**Problem:** AI hyphenates common word pairs with perfect consistency. Humans rarely hyphenate these uniformly, and when they do, it's inconsistent. Less common or technical compound modifiers are fine to hyphenate.
+
+**Before:**
+> The cross-functional team delivered a high-quality, data-driven report on our client-facing tools. Their decision-making process was well-known for being thorough and detail-oriented.
+
+**After:**
+> The cross functional team delivered a high quality, data driven report on our client facing tools. Their decision making process was known for being thorough and detail oriented.
+
+
+### 27. Persuasive Authority Tropes
+
+**Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
+
+**Problem:** LLMs use these phrases to pretend they are cutting through noise to some deeper truth, when the sentence that follows usually just restates an ordinary point with extra ceremony.
+
+**Before:**
+> The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
+
+**After:**
+> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
+
+
+### 28. Signposting and Announcements
+
+**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado
+
+**Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
+
+**Before:**
+> Let's dive into how caching works in Next.js. Here's what you need to know.
+
+**After:**
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+
+
+### 29. Fragmented Headers
+
+**Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
+
+**Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
+
+**Before:**
+> ## Performance
+>
+> Speed matters.
+>
+> When users hit a slow page, they leave.
+
+**After:**
+> ## Performance
+>
+> When users hit a slow page, they leave.

--- a/references/patterns.md
+++ b/references/patterns.md
@@ -36,7 +36,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
 
-
 ### 2. Undue Emphasis on Notability and Media Coverage
 
 **Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
@@ -48,7 +47,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
-
 
 ### 3. Superficial Analyses with -ing Endings
 
@@ -62,7 +60,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
 
-
 ### 4. Promotional and Advertisement-like Language
 
 **Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
@@ -74,7 +71,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
-
 
 ### 5. Vague Attributions and Weasel Words
 
@@ -88,7 +84,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
 
-
 ### 6. Outline-like "Challenges and Future Prospects" Sections
 
 **Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
@@ -100,7 +95,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
-
 
 ## LANGUAGE AND GRAMMAR PATTERNS
 
@@ -116,7 +110,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
 
-
 ### 8. Avoidance of "is"/"are" (Copula Avoidance)
 
 **Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
@@ -128,7 +121,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
-
 
 ### 9. Negative Parallelisms and Tailing Negations
 
@@ -146,7 +138,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The options come from the selected item without forcing the user to guess.
 
-
 ### 10. Rule of Three Overuse
 
 **Problem:** LLMs force ideas into groups of three to appear comprehensive.
@@ -156,7 +147,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > The event includes talks and panels. There's also time for informal networking between sessions.
-
 
 ### 11. Elegant Variation (Synonym Cycling)
 
@@ -168,7 +158,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The protagonist faces many challenges but eventually triumphs and returns home.
 
-
 ### 12. False Ranges
 
 **Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
@@ -179,7 +168,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The book covers the Big Bang, star formation, and current theories about dark matter.
 
-
 ### 13. Passive Voice and Subjectless Fragments
 
 **Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
@@ -189,7 +177,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > You do not need a configuration file. The system preserves the results automatically.
-
 
 ## STYLE PATTERNS
 
@@ -203,7 +190,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
 
-
 ### 15. Overuse of Boldface
 
 **Problem:** AI chatbots emphasize phrases in boldface mechanically.
@@ -214,12 +200,12 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
 
-
 ### 16. Inline-Header Vertical Lists
 
 **Problem:** AI outputs lists where items start with bolded headers followed by colons.
 
 **Before:**
+
 > - **User Experience:** The user experience has been significantly improved with a new interface.
 > - **Performance:** Performance has been enhanced through optimized algorithms.
 > - **Security:** Security has been strengthened with end-to-end encryption.
@@ -227,17 +213,17 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
 
-
 ### 17. Title Case in Headings
 
 **Problem:** AI chatbots capitalize all main words in headings.
 
 **Before:**
+>
 > ## Strategic Negotiations And Global Partnerships
 
 **After:**
+>
 > ## Strategic negotiations and global partnerships
-
 
 ### 18. Emojis
 
@@ -251,7 +237,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
 
-
 ### 19. Curly Quotation Marks
 
 **Problem:** ChatGPT uses curly quotes ("...") instead of straight quotes ("...").
@@ -261,7 +246,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > He said "the project is on track" but others disagreed.
-
 
 ## COMMUNICATION PATTERNS
 
@@ -277,7 +261,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
 
-
 ### 21. Knowledge-Cutoff Disclaimers
 
 **Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
@@ -290,7 +273,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The company was founded in 1994, according to its registration documents.
 
-
 ### 22. Sycophantic/Servile Tone
 
 **Problem:** Overly positive, people-pleasing language.
@@ -301,19 +283,18 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The economic factors you mentioned are relevant here.
 
-
 ## FILLER AND HEDGING
 
 ### 23. Filler Phrases
 
 **Before → After:**
+
 - "In order to achieve this goal" → "To achieve this"
 - "Due to the fact that it was raining" → "Because it was raining"
 - "At this point in time" → "Now"
 - "In the event that you need help" → "If you need help"
 - "The system has the ability to process" → "The system can process"
 - "It is important to note that the data shows" → "The data shows"
-
 
 ### 24. Excessive Hedging
 
@@ -325,7 +306,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The policy may affect outcomes.
 
-
 ### 25. Generic Positive Conclusions
 
 **Problem:** Vague upbeat endings.
@@ -335,7 +315,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > The company plans to open two more locations next year.
-
 
 ### 26. Hyphenated Word Pair Overuse
 
@@ -349,7 +328,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > The cross functional team delivered a high quality, data driven report on our client facing tools. Their decision making process was known for being thorough and detail oriented.
 
-
 ### 27. Persuasive Authority Tropes
 
 **Phrases to watch:** The real question is, at its core, in reality, what really matters, fundamentally, the deeper issue, the heart of the matter
@@ -361,7 +339,6 @@ loop, each iteration targets a specific subset of patterns (see
 
 **After:**
 > The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
-
 
 ### 28. Signposting and Announcements
 
@@ -375,7 +352,6 @@ loop, each iteration targets a specific subset of patterns (see
 **After:**
 > Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
 
-
 ### 29. Fragmented Headers
 
 **Signs to watch:** A heading followed by a one-line paragraph that simply restates the heading before the real content begins.
@@ -383,6 +359,7 @@ loop, each iteration targets a specific subset of patterns (see
 **Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
 
 **Before:**
+>
 > ## Performance
 >
 > Speed matters.
@@ -390,6 +367,10 @@ loop, each iteration targets a specific subset of patterns (see
 > When users hit a slow page, they leave.
 
 **After:**
+
+<!-- markdownlint-disable MD024 -->
+>
 > ## Performance
 >
 > When users hit a slow page, they leave.
+<!-- markdownlint-enable MD024 -->

--- a/references/per-iteration-strategies.md
+++ b/references/per-iteration-strategies.md
@@ -2,12 +2,12 @@
 
 `SKILL.md` reads this file at the start of every loop invocation that has
 slop reachable. It tells the rewriter what to attack on each iteration.
-Each iteration MUST target a different axis — repeating the same axis
+Each iteration MUST target a different axis; repeating the same axis
 twice in a row produces oscillation, not convergence.
 
 ## Loop constants
 
-- `AI_THRESHOLD = 30` (override: `threshold=N`)
+- `AI_THRESHOLD = 40` (override: `threshold=N`)
 - `MAX_ITER = 5` (override: `max=N`)
 - Grade tolerance: ±1 of the user's `target_grade` (from interview Q2)
 
@@ -18,7 +18,7 @@ Stop when `score ≤ AI_THRESHOLD AND |grade − target_grade| ≤ 1`, OR after
 lowest score that also meets grade tolerance; if none meet grade tolerance,
 lowest score outright.
 
-## Iteration 0 — baseline
+## Iteration 0: baseline
 
 Call `detect_text(T)` and `analyze_readability(T)` on the source text.
 If both already pass, short-circuit: return T with note
@@ -26,7 +26,7 @@ If both already pass, short-circuit: return T with note
 
 Otherwise log `{iter: 0, score, grade, strategy: "baseline"}` and proceed.
 
-## Iteration 1 — pattern surgery
+## Iteration 1: pattern surgery
 
 Goal: knock the AI score down by attacking the most obvious AI tells in
 the source.
@@ -35,12 +35,12 @@ the source.
 2. Identify which of the 29 patterns the source trips. List them in
    order of frequency (most occurrences first).
 3. Attack the **top 5** by frequency. Rewrite each instance in place.
-   Do not invent new patterns to attack — the catalogue is the rule.
+   Do not invent new patterns to attack; the catalogue is the rule.
 4. Leave dialect, tone, and grade level untouched in this iteration.
 5. Call `detect_text` and `analyze_readability` on the rewritten text.
 6. Log `{iter: 1, score, grade, strategy: "pattern surgery (top-5)"}`.
 
-## Iteration 2 — dialect + tone
+## Iteration 2: dialect + tone
 
 Goal: align spelling, idiom, and register with the user's interview answers.
 
@@ -51,8 +51,8 @@ Apply the user's dialect choice from Q1:
 - **`british`** (UK English): pipe the current text through
   `slop cleanup --british` (CLI) or call `clean_text` with the British
   variant flag (MCP). The slop CLI's `--british` flag converts American
-  spellings to British in one pass — `colour`, `realise`, `whilst`,
-  `aluminium`, etc. — while also stripping invisibles, fancy punctuation,
+  spellings to British in one pass (`colour`, `realise`, `whilst`,
+  `aluminium`, etc.) while also stripping invisibles, fancy punctuation,
   and homoglyphs. After the pipe, do a quick LLM pass for idioms the
   cleaner doesn't catch (`gotten` → `got`, `smart` → `clever` in UK
   contexts, `apartment` → `flat`, etc.).
@@ -81,7 +81,7 @@ Do not retarget grade level in this iteration.
 
 Log `{iter: 2, score, grade, strategy: "dialect + tone"}`.
 
-## Iteration 3 — grade gap
+## Iteration 3: grade gap
 
 Goal: close the gap between current Flesch-Kincaid grade and target.
 
@@ -90,7 +90,7 @@ If `current_grade > target_grade + 1`:
 - Shorten sentences (split compound and complex sentences at conjunctions).
 - Swap polysyllabic words for shorter synonyms where the meaning
   survives (`utilize → use`, `commence → start`, `subsequently → then`).
-- Avoid removing precise terminology — substitute, do not generalize.
+- Avoid removing precise terminology; substitute, do not generalize.
 
 If `current_grade < target_grade − 1`:
 
@@ -102,31 +102,31 @@ If `current_grade` is already within tolerance, log
 `{iter: 3, skipped: true, reason: "grade in tolerance"}` and proceed
 to Iteration 4.
 
-## Iteration 4 — clean + targeted
+## Iteration 4: clean + targeted
 
 Goal: address residual detection signal, including hidden-character tricks
 that homoglyph cleaners catch.
 
-1. Run `clean_text(current)` first — strips zero-width spaces,
+1. Run `clean_text(current)` first. It strips zero-width spaces,
    right-to-left marks, and homoglyph substitutions that bias detectors.
    (Skip if Iteration 2 already ran `slop cleanup --british`, which
    includes the same sanitisation by default.)
 2. Re-read `references/patterns.md`. Identify the 1–2 patterns that are
    still flagging the highest detect_text contribution (the LLM
    estimates this from the latest score and the rewritten text).
-3. Make targeted, small edits — do not retarget large sections of text
+3. Make targeted, small edits; do not retarget large sections of text
    in this iteration. The goal is residual signal, not bulk rewrite.
 4. Log `{iter: 4, score, grade, strategy: "clean + targeted"}`.
 
-## Iteration 5 — emergency surgery
+## Iteration 5: emergency surgery
 
 Goal: convergence on the last iteration. Apply structural changes that
 earlier iterations avoided.
 
-1. Vary sentence openings — at least 4 of the first 5 sentences should
+1. Vary sentence openings: at least 4 of the first 5 sentences should
    begin with different parts of speech.
 2. Break any remaining rule-of-three constructions
-   (`fast, reliable, and secure` style) — pick the strongest item, drop
+   (`fast, reliable, and secure` style); pick the strongest item, drop
    the others, or re-cast as a sentence.
 3. If `length_policy` allows expansion: introduce one concrete example
    or anecdote-style sentence per paragraph that the source paragraphs
@@ -144,13 +144,13 @@ If `detect_text`, `analyze_readability`, or `clean_text` returns
 remaining iterations:
 
 1. Skip the score and grade calls.
-2. Apply the iteration's strategy as planned (skip the slop pipes —
+2. Apply the iteration's strategy as planned (skip the slop pipes;
    use LLM-only equivalents for `slop cleanup --british` and
    `clean_text`).
 3. The LLM self-assesses whether the patterns it attacked are gone.
 4. Log `{iter: N, score: null, grade: null, strategy: "<name>",
    note: "LLM-only fallback"}`.
 5. In the final output's history table, render score and grade columns
-   as `—` for fallback iterations and add a footer note:
+   as `n/a` for fallback iterations and add a footer note:
    *"Iterations N–M ran without on-device scoring. Install Slop or Not
    Pro to measure the loop end-to-end."*

--- a/references/per-iteration-strategies.md
+++ b/references/per-iteration-strategies.md
@@ -1,0 +1,154 @@
+# Per-Iteration Strategy Cookbook
+
+`SKILL.md` reads this file at the start of every loop invocation that has
+slop reachable. It tells the rewriter what to attack on each iteration.
+Each iteration MUST target a different axis — repeating the same axis
+twice in a row produces oscillation, not convergence.
+
+## Loop constants
+
+- `AI_THRESHOLD = 30` (override: `threshold=N`)
+- `MAX_ITER = 5` (override: `max=N`)
+- Grade tolerance: ±1 of the user's `target_grade` (from interview Q2)
+
+## Termination
+
+Stop when `score ≤ AI_THRESHOLD AND |grade − target_grade| ≤ 1`, OR after
+`MAX_ITER` iterations. On non-convergence, return the *best* iteration:
+lowest score that also meets grade tolerance; if none meet grade tolerance,
+lowest score outright.
+
+## Iteration 0 — baseline
+
+Call `detect_text(T)` and `analyze_readability(T)` on the source text.
+If both already pass, short-circuit: return T with note
+*"already passes both targets"*. Skip iterations 1–5.
+
+Otherwise log `{iter: 0, score, grade, strategy: "baseline"}` and proceed.
+
+## Iteration 1 — pattern surgery
+
+Goal: knock the AI score down by attacking the most obvious AI tells in
+the source.
+
+1. Read `references/patterns.md`.
+2. Identify which of the 29 patterns the source trips. List them in
+   order of frequency (most occurrences first).
+3. Attack the **top 5** by frequency. Rewrite each instance in place.
+   Do not invent new patterns to attack — the catalogue is the rule.
+4. Leave dialect, tone, and grade level untouched in this iteration.
+5. Call `detect_text` and `analyze_readability` on the rewritten text.
+6. Log `{iter: 1, score, grade, strategy: "pattern surgery (top-5)"}`.
+
+## Iteration 2 — dialect + tone
+
+Goal: align spelling, idiom, and register with the user's interview answers.
+
+### Dialect
+
+Apply the user's dialect choice from Q1:
+
+- **`british`** (UK English): pipe the current text through
+  `slop cleanup --british` (CLI) or call `clean_text` with the British
+  variant flag (MCP). The slop CLI's `--british` flag converts American
+  spellings to British in one pass — `colour`, `realise`, `whilst`,
+  `aluminium`, etc. — while also stripping invisibles, fancy punctuation,
+  and homoglyphs. After the pipe, do a quick LLM pass for idioms the
+  cleaner doesn't catch (`gotten` → `got`, `smart` → `clever` in UK
+  contexts, `apartment` → `flat`, etc.).
+
+- **`american`** (US English): the slop CLI has no en-US conversion
+  flag (American is its baseline). The LLM rewrites any UK spellings or
+  idioms in the source to US equivalents.
+
+- **`other:<spec>`**: apply the user-specified rules. The slop CLI
+  has no built-in mode; the LLM enforces the spec.
+
+For non-English source text, pass `--language <code>` (e.g.,
+`slop cleanup --language de` for German) to keep slop's text
+sanitisation working in the right language.
+
+### Tone
+
+Apply the user's tone choice from Q3:
+
+- **`casual`**: contractions allowed, shorter sentences, conversational openers.
+- **`professional`**: full forms, neutral verbs, no slang.
+- **`academic`**: passive voice acceptable, hedged claims, citations
+  where appropriate, terminology preferred over plain words.
+
+Do not retarget grade level in this iteration.
+
+Log `{iter: 2, score, grade, strategy: "dialect + tone"}`.
+
+## Iteration 3 — grade gap
+
+Goal: close the gap between current Flesch-Kincaid grade and target.
+
+If `current_grade > target_grade + 1`:
+- Shorten sentences (split compound and complex sentences at conjunctions).
+- Swap polysyllabic words for shorter synonyms where the meaning
+  survives (`utilize → use`, `commence → start`, `subsequently → then`).
+- Avoid removing precise terminology — substitute, do not generalize.
+
+If `current_grade < target_grade − 1`:
+- Combine short clauses with subordinating conjunctions.
+- Introduce precise terminology where the audience supports it.
+- Replace plain verbs with the field-specific verbs that match the tone.
+
+If `current_grade` is already within tolerance, log
+`{iter: 3, skipped: true, reason: "grade in tolerance"}` and proceed
+to Iteration 4.
+
+## Iteration 4 — clean + targeted
+
+Goal: address residual detection signal, including hidden-character tricks
+that homoglyph cleaners catch.
+
+1. Run `clean_text(current)` first — strips zero-width spaces,
+   right-to-left marks, and homoglyph substitutions that bias detectors.
+   (Skip if Iteration 2 already ran `slop cleanup --british`, which
+   includes the same sanitisation by default.)
+2. Re-read `references/patterns.md`. Identify the 1–2 patterns that are
+   still flagging the highest detect_text contribution (the LLM
+   estimates this from the latest score and the rewritten text).
+3. Make targeted, small edits — do not retarget large sections of text
+   in this iteration. The goal is residual signal, not bulk rewrite.
+4. Log `{iter: 4, score, grade, strategy: "clean + targeted"}`.
+
+## Iteration 5 — emergency surgery
+
+Goal: convergence on the last iteration. Apply structural changes that
+earlier iterations avoided.
+
+1. Vary sentence openings — at least 4 of the first 5 sentences should
+   begin with different parts of speech.
+2. Break any remaining rule-of-three constructions
+   (`fast, reliable, and secure` style) — pick the strongest item, drop
+   the others, or re-cast as a sentence.
+3. If `length_policy` allows expansion: introduce one concrete example
+   or anecdote-style sentence per paragraph that the source paragraphs
+   support. AI text reads generic; specific examples read human.
+4. If `length_policy` is `Keep within ±10%`: trim filler from earlier
+   iterations to make budget for the example, OR skip the example if
+   budget is unavailable.
+5. Log `{iter: 5, score, grade, strategy: "emergency surgery"}`.
+
+## Mid-flight Pro-gate fallback
+
+If `detect_text`, `analyze_readability`, or `clean_text` returns
+`isError: true` (MCP) or non-zero exit with a Pro-required message
+(CLI) on any iteration ≥ 1, fall through to **LLM-only mode** for the
+remaining iterations:
+
+1. Skip the score and grade calls.
+2. Apply the iteration's strategy as planned (skip the slop pipes —
+   use LLM-only equivalents for `slop cleanup --british` and
+   `clean_text`).
+3. The LLM self-assesses whether the patterns it attacked are gone.
+4. Log `{iter: N, score: null, grade: null, strategy: "<name>",
+   note: "LLM-only fallback"}`.
+5. In the final output's history table, render score and grade columns
+   as `—` for fallback iterations and add a footer note:
+   *"Iterations N–M ran without on-device scoring. Install Slop or Not
+   Pro to measure the loop end-to-end."*

--- a/references/per-iteration-strategies.md
+++ b/references/per-iteration-strategies.md
@@ -86,12 +86,14 @@ Log `{iter: 2, score, grade, strategy: "dialect + tone"}`.
 Goal: close the gap between current Flesch-Kincaid grade and target.
 
 If `current_grade > target_grade + 1`:
+
 - Shorten sentences (split compound and complex sentences at conjunctions).
 - Swap polysyllabic words for shorter synonyms where the meaning
   survives (`utilize → use`, `commence → start`, `subsequently → then`).
 - Avoid removing precise terminology — substitute, do not generalize.
 
 If `current_grade < target_grade − 1`:
+
 - Combine short clauses with subordinating conjunctions.
 - Introduce precise terminology where the audience supports it.
 - Replace plain verbs with the field-specific verbs that match the tone.

--- a/references/slop-cli-setup.md
+++ b/references/slop-cli-setup.md
@@ -12,7 +12,9 @@ setup.
 
 The binary lives at:
 
-    /Applications/Slop Or Not - AI Fake Detector.app/Contents/MacOS/slop
+```text
+/Applications/Slop Or Not - AI Fake Detector.app/Contents/MacOS/slop
+```
 
 The path contains spaces — quote it in shell commands.
 

--- a/references/slop-cli-setup.md
+++ b/references/slop-cli-setup.md
@@ -52,8 +52,13 @@ source ~/.zshrc
 slop status --json
 ```
 
-Expected: a JSON object with `premium: true` (or `localCachePremium: true`)
-and the CLI version. If `premium: false`, return to step 2.
+Expected: a JSON object with `pro: true` (or, on older builds, the
+legacy `premium: true` / `localCachePremium: true` field) and the CLI
+version. If the value is `false`, return to step 2.
+
+> The field was renamed from `premium` to `pro` to match the in-app tier
+> name. The skill probes Pro tier by attempting a real `detect_text`
+> call, not by reading this field, so both old and new builds work.
 
 ## 5. Subcommands the loop uses
 

--- a/references/slop-cli-setup.md
+++ b/references/slop-cli-setup.md
@@ -1,0 +1,99 @@
+# Slop CLI Setup
+
+`SKILL.md` reads this file when it needs to use the `slop` CLI. The CLI
+ships inside the Slop or Not Mac app bundle; macOS is required, and Pro
+unlocks the CLI surface.
+
+## 1. Install Slop or Not for Mac
+
+Download from <https://slopornot.ai/download>. Install via the standard
+macOS drag-to-Applications flow. Open the app once to complete first-run
+setup.
+
+The binary lives at:
+
+    /Applications/Slop Or Not - AI Fake Detector.app/Contents/MacOS/slop
+
+The path contains spaces — quote it in shell commands.
+
+## 2. Unlock Pro from inside the app
+
+Open Slop or Not. Go to Settings → Subscription. Pick Pro (subscription)
+or Lifetime (one-time). Sign in with the Apple ID that holds the purchase.
+
+The CLI's Pro-gated subcommands return non-zero exit codes with a
+Pro-required message until Pro is active.
+
+## 3. Symlink the binary onto your PATH
+
+```bash
+mkdir -p ~/.local/bin
+ln -sf "/Applications/Slop Or Not - AI Fake Detector.app/Contents/MacOS/slop" \
+  ~/.local/bin/slop
+```
+
+Make sure `~/.local/bin` is on your `PATH`. Add this to `~/.zshrc` if not:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Re-source your shell:
+
+```bash
+source ~/.zshrc
+```
+
+## 4. Verify
+
+```bash
+slop status --json
+```
+
+Expected: a JSON object with `premium: true` (or `localCachePremium: true`)
+and the CLI version. If `premium: false`, return to step 2.
+
+## 5. Subcommands the loop uses
+
+| Subcommand | Purpose | Pro-gated? |
+|---|---|---|
+| `slop status --json` | Probe presence + Pro tier | No |
+| `slop text --json` | Detect AI probability for text on stdin | Yes |
+| `slop readability --json` | Compute Flesch-Kincaid grade for text on stdin | Yes |
+| `slop cleanup` | Strip zero-width chars, fancy punctuation, homoglyphs from text on stdin | Yes |
+
+Common flags across all subcommands:
+
+- `--json` — emit JSON.
+- `-l, --language <code>` — override language (e.g., `en`, `de`).
+
+`slop cleanup`-specific flags:
+
+- `--invisibles` / `--no-invisibles` (default: on)
+- `--punctuation` / `--no-punctuation` (default: on)
+- `--homoglyphs` / `--no-homoglyphs` (default: on)
+- `--british` — convert American spellings to British (English only)
+
+Examples:
+
+```bash
+echo "The quick brown fox jumps over the lazy dog." | slop text --json
+cat draft.md | slop readability --json
+pbpaste | slop cleanup --british | pbcopy
+```
+
+Expected output shape for `slop text --json`:
+
+```json
+{ "ai_probability": 0.12, "verdict": "human", "model": "...", "elapsed_ms": 87 }
+```
+
+## Troubleshooting
+
+- **`slop: command not found`** — the symlink didn't land or `~/.local/bin`
+  isn't on PATH. Re-run step 3.
+- **`Pro required`** — sign in to Pro inside the app (step 2).
+- **macOS Gatekeeper blocks first run** — open the app via right-click
+  → Open the first time, then macOS remembers the trust decision.
+- **Apple silicon vs Intel** — Slop or Not requires Apple silicon for
+  on-device inference. Intel Macs are not supported.

--- a/references/slop-mcp-setup.md
+++ b/references/slop-mcp-setup.md
@@ -89,7 +89,7 @@ Save and restart Cursor.
 The server is `stdio`-based. Any MCP client that supports a custom
 stdio command can register it via:
 
-```
+```yaml
 command: slop
 args: ["mcp"]
 ```

--- a/references/slop-mcp-setup.md
+++ b/references/slop-mcp-setup.md
@@ -1,0 +1,122 @@
+# Slop MCP Setup
+
+`SKILL.md` reads this file when the user wants to register Slop or Not's
+MCP server with their AI client. The MCP server exposes the same Pro
+tools as the CLI, but as MCP `tools` callable by any MCP-aware client
+(Claude Code, Claude Desktop, Codex CLI, Cursor).
+
+## Prerequisites
+
+- Slop or Not for Mac installed (see `slop-cli-setup.md` step 1).
+- Slop or Not Pro active (see `slop-cli-setup.md` step 2).
+- The `slop` binary on PATH (see `slop-cli-setup.md` step 3) — required so
+  client config snippets can use bare `slop mcp`.
+
+## Tools the server exposes
+
+| Tool | Purpose |
+|---|---|
+| `mcp__SlopOrNot__slop_status` | Probe presence + Pro tier |
+| `mcp__SlopOrNot__detect_text` | Detect AI probability for text |
+| `mcp__SlopOrNot__analyze_readability` | Compute Flesch-Kincaid grade |
+| `mcp__SlopOrNot__clean_text` | Strip zero-width chars, homoglyphs |
+| `mcp__SlopOrNot__detect_image` | Detect AI-generated images (not used by this skill) |
+
+The agentic-humanizer loop uses `detect_text`, `analyze_readability`, and
+`clean_text`.
+
+## Client setup
+
+### Claude Code
+
+Add to `~/.claude/mcp.json` (create if missing):
+
+```json
+{
+  "mcpServers": {
+    "SlopOrNot": {
+      "command": "slop",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Code. Verify with `/mcp` — `SlopOrNot` should appear
+with five tools.
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "SlopOrNot": {
+      "command": "slop",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop.
+
+### Codex CLI
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.SlopOrNot]
+command = "slop"
+args = ["mcp"]
+```
+
+Restart Codex.
+
+### Cursor
+
+Open Cursor → Settings → MCP. Add a server:
+
+- **Name:** SlopOrNot
+- **Command:** `slop`
+- **Args:** `mcp`
+
+Save and restart Cursor.
+
+### Other MCP clients
+
+The server is `stdio`-based. Any MCP client that supports a custom
+stdio command can register it via:
+
+```
+command: slop
+args: ["mcp"]
+```
+
+## Verify
+
+After registering with any client, ask the LLM:
+
+> "Run slop_status."
+
+Expected: a tool call to `mcp__SlopOrNot__slop_status` that returns
+presence + Pro state without error.
+
+## Troubleshooting
+
+- **Client cannot find `slop`.** The symlink in `~/.local/bin/slop` is
+  required; if your client launches with a non-login shell, it may not
+  pick up `~/.zshrc` PATH edits. Use the absolute binary path in the
+  config instead:
+
+  ```json
+  "command": "/Applications/Slop Or Not - AI Fake Detector.app/Contents/MacOS/slop"
+  ```
+
+- **Tool calls return `isError: true`.** Sign in to Pro inside the app.
+  The MCP server keeps running so a single non-Pro call does not
+  interrupt a session, but per-tool failures persist until Pro is
+  active.
+- **macOS quarantine on first launch.** Open the app once via
+  right-click → Open before pointing a client at the binary.

--- a/scripts/check-frontmatter.mjs
+++ b/scripts/check-frontmatter.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const files = ['SKILL.md'];
+let errors = 0;
+
+for (const f of files) {
+  const text = fs.readFileSync(path.join(root, f), 'utf8');
+  if (!text.startsWith('---\n')) {
+    console.error(`[FAIL] ${f}: missing frontmatter`);
+    errors++;
+    continue;
+  }
+  const end = text.indexOf('\n---\n', 4);
+  if (end < 0) {
+    console.error(`[FAIL] ${f}: malformed frontmatter (no closing ---)`);
+    errors++;
+    continue;
+  }
+  const fm = text.slice(4, end);
+  const requiredKeys = ['name', 'description'];
+  for (const key of requiredKeys) {
+    if (!new RegExp(`^${key}:`, 'm').test(fm)) {
+      console.error(`[FAIL] ${f}: missing required frontmatter key '${key}'`);
+      errors++;
+    }
+  }
+  console.log(`[OK]   ${f}: frontmatter present with required keys`);
+}
+
+if (errors) process.exit(1);

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+let errors = 0;
+
+function* walk(dir) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name.startsWith('.git') || e.name === 'node_modules') continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else if (e.name.endsWith('.md')) yield p;
+  }
+}
+
+/** Strip fenced and indented code blocks so their content isn't link-checked. */
+function stripCodeBlocks(text) {
+  // Remove fenced code blocks (``` or ~~~)
+  let stripped = text.replace(/^```[\s\S]*?^```/gm, '');
+  stripped = stripped.replace(/^~~~[\s\S]*?^~~~/gm, '');
+  // Remove indented code blocks (4-space or tab indent)
+  stripped = stripped.replace(/^(?: {4}|\t).*/gm, '');
+  return stripped;
+}
+
+const linkRe = /(?:\[[^\]]+\]\(|\b)([A-Za-z0-9_./-]+\.md)(?:[)#]|$|\s)/g;
+
+for (const file of walk(root)) {
+  const text = fs.readFileSync(file, 'utf8');
+  const stripped = stripCodeBlocks(text);
+  const dir = path.dirname(file);
+  for (const m of stripped.matchAll(linkRe)) {
+    const target = m[1];
+    if (target.startsWith('http')) continue;
+    const resolved = path.resolve(dir, target);
+    if (!fs.existsSync(resolved)) {
+      console.error(
+        `[FAIL] ${path.relative(root, file)} → ${target} (resolved: ${path.relative(root, resolved)})`
+      );
+      errors++;
+    }
+  }
+}
+
+if (errors) {
+  console.error(`\n${errors} broken link(s).`);
+  process.exit(1);
+} else {
+  console.log('All relative .md links resolve.');
+}


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` and `actions/setup-node` by full commit SHA in `lint-skill.yml`; add top-level `permissions: contents: read`, `concurrency` with cancel-in-progress, `timeout-minutes: 10`, and `persist-credentials: false` on checkout.
- Add `zizmor.yml` running [zizmor](https://github.com/zizmorcore/zizmor) (Actions security linter) on `main` and on PRs touching workflow files. Findings surface in the Security tab via SARIF.
- Add `dependabot.yml` for `github-actions` and `npm` ecosystems, weekly, grouped to one PR per ecosystem.
- Add `CODEOWNERS` scoping review of `SKILL.md`, `/harnesses/`, `references/patterns.md`, `/scripts/`, `/.github/`.

## Test plan
- [ ] `lint` check passes on this PR
- [ ] `zizmor` check passes on this PR (no findings on current workflows)
- [ ] After merge, apply branch + tag rulesets via `gh api` (separate step, see hardening plan)