### PR TITLE
Add pattern #30: debunking-pose headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
-## 29 Patterns Detected (with Before/After Examples)
+## 30 Patterns Detected (with Before/After Examples)
 
 ### Content Patterns
 
@@ -127,6 +127,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 27 | **Persuasive authority tropes** | "At its core, what matters is..." | State the point directly |
 | 28 | **Signposting announcements** | "Let's dive in", "Here's what you need to know" | Start with the content |
 | 29 | **Fragmented headers** | "## Performance" + "Speed matters." | Let the heading do the work |
+| 30 | **Debunking-pose headings** | "What the research actually says", "X: the long game" | Cut "actually / the real / that lands" and let the heading sit plain |
 
 ### Communication Patterns
 
@@ -179,6 +180,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.6.0** - Added pattern #30: debunking-pose headings ("actually," "the real," "that lands," "the long game" etc.), raising the total to 30 patterns. Editors usually treat headings as structure and leave them alone, so this pose slips through prose-level passes; the new pattern asks for an explicit heading audit.
 - **2.5.1** - Added a passive-voice / subjectless-fragment rule, raising the total to 29 patterns
 - **2.5.0** - Added patterns for persuasive framing, signposting, and fragmented headers; expanded negative parallelisms to cover tailing negations; tightened wording around em dash overuse; fixed frontmatter wording to use "filler phrases"
 - **2.4.0** - Added voice calibration: match the user's personal writing style from samples

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: humanizer
-version: 2.5.1
+version: 2.6.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
   comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
   inflated symbolism, promotional language, superficial -ing analyses, vague
   attributions, em dash overuse, rule of three, AI vocabulary words, passive
-  voice, negative parallelisms, and filler phrases.
+  voice, negative parallelisms, debunking-pose headings, and filler phrases.
 license: MIT
 compatibility: claude-code opencode
 allowed-tools:
@@ -460,6 +460,31 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 > ## Performance
 >
 > When users hit a slow page, they leave.
+
+
+### 30. Debunking-Pose Headings
+
+**Phrases to watch (in headings):** actually, really, the real X, that lands, that works, that matters, the truth about X, what X really means, the death of, the long game, demystified, explained, decoded, rethought, reimagined
+
+**Problem:** LLMs write headings that pose against an implied wrong version of the topic: "actually," "the real," "that lands," "the truth about." The pose announces *everyone else has it slightly wrong, but I'll give you the truth* — without delivering anything different than a plain heading would. This is pattern #27 (Persuasive Authority Tropes) operating at the heading level. It's also a sibling of pattern #1 (Significance Inflation): the heading promises a reveal it cannot keep.
+
+The pattern is hardest to see because headings read as structure rather than copy, and editors instinctively leave them alone. Audit headings explicitly as a separate pass.
+
+**Before:**
+> ## What the research actually says
+> ## Why your adult child cut you off (the real map)
+> ## The architecture of a letter that lands
+> ## Grandchildren: the long game
+> ## The truth about pricing models, explained
+
+**After:**
+> ## What the research says
+> ## Why your adult child cut you off
+> ## The architecture of an amends letter
+> ## Grandchildren
+> ## How pricing models work
+
+Keep the pose only when the chapter genuinely overturns a specific received view, and name that view in the opening paragraph. Otherwise cut the pose and let the content do the work.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a 30th pattern to the humanizer skill: **debunking-pose headings**.

The existing 29 patterns target prose. Headings often slip through editing passes because editors (human and AI) treat them as structure rather than copy. A common AI tell is a heading that *poses* against an implied wrong version of the topic: "actually," "the real," "that lands," "the truth about," "the long game," "demystified." The pose announces *everyone else has it slightly wrong, but I'll give you the truth* — without delivering anything different than a plain heading would.

This is pattern #27 (Persuasive Authority Tropes) operating at the heading level, and a sibling of pattern #1 (Significance Inflation): the heading promises a reveal it cannot keep.

I discovered this when I ran the skill across a 24-chapter book in parallel. The agents cleaned the prose beautifully but left every "actually / the real / that lands / the long game" title intact. Two reasons: (a) the skill's 29 patterns are written for prose with prose examples, and (b) editors instinctively leave headings alone. So this pose lives in a gap between the two.

## Changes

- **SKILL.md**: New `### 30. Debunking-Pose Headings` section after pattern #29 with phrases-to-watch, problem statement, and before/after heading examples. Asks editors to audit headings as a separate pass.
- **README.md**: New row in the Style Patterns table, pattern count updated `29 → 30`, version history entry for 2.6.0.
- **SKILL.md frontmatter**: `version: 2.5.1 → 2.6.0`, description updated to include "debunking-pose headings."

## Test plan
- [ ] Read the new pattern #30 entry — does the before/after capture the tell?
- [ ] Spot-check whether the phrase list is the right set (suggestions welcome — I leaned on what surfaced in the book I tested it on)
- [ ] Confirm version bump is appropriate (minor: additive pattern, no breaking change)

Happy to revise if any of the wording or framing doesn't fit the project's voice.