### PR TITLE
Strengthen humanizer factual integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ mkdir -p ~/.claude/skills
 git clone https://github.com/blader/humanizer.git ~/.claude/skills/humanizer
 ```
 
-Or copy the skill file manually if you already have this repo cloned:
+Or copy the skill and references manually if you already have this repo cloned:
 
 ```bash
 mkdir -p ~/.claude/skills/humanizer
 cp SKILL.md ~/.claude/skills/humanizer/
+cp -R references ~/.claude/skills/humanizer/
 ```
 
 ### OpenCode
@@ -29,11 +30,12 @@ mkdir -p ~/.config/opencode/skills
 git clone https://github.com/blader/humanizer.git ~/.config/opencode/skills/humanizer
 ```
 
-Or copy the skill file manually if you already have this repo cloned:
+Or copy the skill and references manually if you already have this repo cloned:
 
 ```bash
 mkdir -p ~/.config/opencode/skills/humanizer
 cp SKILL.md ~/.config/opencode/skills/humanizer/
+cp -R references ~/.config/opencode/skills/humanizer/
 ```
 
 > **Note:** OpenCode also scans `~/.claude/skills/` for compatibility, so a single clone into `~/.claude/skills/humanizer/` works for both tools.
@@ -82,13 +84,15 @@ The skill will analyze your sentence rhythm, word choices, and quirks, then appl
 
 Based on [Wikipedia's "Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) guide, maintained by WikiProject AI Cleanup. This comprehensive guide comes from observations of thousands of instances of AI-generated text.
 
-The skill also includes a final "obviously AI generated" audit pass and a second rewrite, to catch lingering AI-isms in the first draft.
+The skill also includes a final "obviously AI generated" audit pass and a second rewrite, to catch lingering AI-isms in the first draft. For dense drafts, it can load `references/banned-list.md`, a comprehensive list of phrases, transitions, emojis, fake names, and style patterns to remove.
+
+It now has a hard factual-integrity rule: do not add facts, names, numbers, sources, quotes, examples, prices, dates, or claims unless the user supplied them.
 
 ### Key Insight from Wikipedia
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
-## 29 Patterns Detected (with Before/After Examples)
+## 31 Patterns Detected (with Before/After Examples)
 
 ### Content Patterns
 
@@ -127,6 +131,8 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 27 | **Persuasive authority tropes** | "At its core, what matters is..." | State the point directly |
 | 28 | **Signposting announcements** | "Let's dive in", "Here's what you need to know" | Start with the content |
 | 29 | **Fragmented headers** | "## Performance" + "Speed matters." | Let the heading do the work |
+| 30 | **Fake naming** | "The Feedback Loop Method" | Describe the idea normally |
+| 31 | **Self-narration / rhetorical hooks** | "This highlights...", "The key takeaway is..." | Make the point directly |
 
 ### Communication Patterns
 
@@ -164,21 +170,21 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 > In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you’d like me to expand on any section!
 
 **After (Humanized):**
-> AI coding assistants can speed up the boring parts of the job. They're great at boilerplate: config files and the little glue code you don't want to write. They can also help you sketch a test, but you still have to read it.
+> AI coding assistants can help with documentation and tests. They can also help with refactors, but weak suggestions often look polished, so the value depends on whether someone reviews the output.
 >
-> The dangerous part is how confident the suggestions look. I've accepted code that compiled and passed lint, then discovered later it missed the point because I stopped paying attention.
+> The adoption claims in this draft are hard to judge. "Industry observers" and broad media mentions do not say much without named sources or actual data.
 >
-> If you treat it like autocomplete and review every line, it's useful. If you use it to avoid thinking, it will help you ship bugs faster.
->
-> The only real backstop is tests. Without them, you're mostly judging vibes.
+> The safest summary is simple: these tools may speed up parts of software work, but teams still need human review and tests.
 
 ## References
 
 - [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) - Primary source
 - [WikiProject AI Cleanup](https://en.wikipedia.org/wiki/Wikipedia:WikiProject_AI_Cleanup) - Maintaining organization
+- [`references/banned-list.md`](references/banned-list.md) - Comprehensive local banned-list reference
 
 ## Version History
 
+- **2.6.0** - Ported the stricter notes-humanizer guardrails: factual-integrity rule, hard bans for fake naming/self-narration/hooks, reference banned-list, no-preamble default output, and safer examples that avoid invented specifics
 - **2.5.1** - Added a passive-voice / subjectless-fragment rule, raising the total to 29 patterns
 - **2.5.0** - Added patterns for persuasive framing, signposting, and fragmented headers; expanded negative parallelisms to cover tailing negations; tightened wording around em dash overuse; fixed frontmatter wording to use "filler phrases"
 - **2.4.0** - Added voice calibration: match the user's personal writing style from samples

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: humanizer
-version: 2.5.1
+version: 2.6.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
   comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
   inflated symbolism, promotional language, superficial -ing analyses, vague
   attributions, em dash overuse, rule of three, AI vocabulary words, passive
-  voice, negative parallelisms, and filler phrases.
+  voice, negative parallelisms, fake naming, self-narration, and filler phrases.
 license: MIT
 compatibility: claude-code opencode
 allowed-tools:
@@ -30,9 +30,28 @@ When given text to humanize:
 1. **Identify AI patterns** - Scan for the patterns listed below
 2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
 3. **Preserve meaning** - Keep the core message intact
-4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
-5. **Add soul** - Don't just remove bad patterns; inject actual personality
-6. **Do a final anti-AI pass** - Prompt: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise
+4. **Protect factual integrity** - Do not add facts, names, numbers, sources, quotes, examples, prices, dates, or claims unless the user supplied them
+5. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
+6. **Add soul** - Don't just remove bad patterns; inject actual personality
+7. **Do a final anti-AI pass** - Ask yourself "What makes the below so obviously AI generated?", fix the remaining tells, then deliver the final version
+
+
+## Hard Rules
+
+1. **Do not invent details.** If the source is vague, keep the rewrite vague or ask for missing facts. Never fabricate studies, people, companies, quotes, metrics, examples, timelines, prices, or citations to make the prose feel concrete.
+2. **No em dashes.** Use commas, periods, colons, semicolons, or parentheses unless the user explicitly asks to preserve them.
+3. **No forced rule-of-three lists.** Use the number of items the content naturally needs.
+4. **No contrast framing.** Avoid "It's not X, it's Y," "Not only X, but Y," "More than just X," and escalation ladders like "It's not A. It's not even B. It's C."
+5. **No dramatic staccato bursts.** Do not stack three or more short sentences for effect.
+6. **No rhetorical transition hooks.** Delete "The catch?", "The kicker?", "Here's the thing," "So what does this mean?", and similar setup lines unless a real question belongs there.
+7. **No fake naming.** Do not capitalize ordinary ideas into invented frameworks, methods, paradoxes, or flywheels.
+8. **No self-narration.** Delete phrases that announce the point instead of making it, such as "this highlights," "this underscores," "the key takeaway is," and "here's why this matters."
+9. **No chatbot wrapper.** Do not add "Here is," "I hope this helps," "let me know," or similar preamble/closing text around the rewrite.
+
+
+## Reference Files
+
+For dense AI-sounding drafts, read `references/banned-list.md`. It contains the comprehensive lists of transition words, adjectives, adverbs, abstract nouns, verbs, phrases, emojis, contrast frames, fake names, and style patterns to remove.
 
 
 ## Voice Calibration (Optional)
@@ -432,7 +451,7 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 ### 28. Signposting and Announcements
 
-**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado
+**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado, nobody talks about this, nobody tells you this
 
 **Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
 
@@ -461,32 +480,57 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 >
 > When users hit a slow page, they leave.
 
+
+### 30. Fake Naming
+
+**Signs to watch:** The Productivity Paradox, The 3C Framework, The Feedback Loop Method, The Innovation Flywheel, The Growth Paradox, The 5-Step Method
+
+**Problem:** LLMs turn ordinary observations into title-cased concepts to make weak structure look authoritative. Unless the name already exists outside the draft, it reads fake.
+
+**Before:**
+> The Feedback Loop Method helps teams improve communication by reviewing what worked and what did not.
+
+**After:**
+> Teams can improve communication by reviewing what worked and what did not.
+
+
+### 31. Self-Narration and Rhetorical Hooks
+
+**Phrases to watch:** this highlights, this underscores, this speaks to, here's why this matters, the key takeaway is, the big picture here is, now for the interesting part, what does this mean?
+
+**Problem:** These phrases announce the point instead of making it. They add a narrator voice that makes the writing feel like a generated explainer.
+
+**Before:**
+> This highlights why onboarding matters. The key takeaway is that users need a faster first-run experience.
+
+**After:**
+> Users need a faster first-run experience.
+
 ---
 
 ## Process
 
 1. Read the input text carefully
 2. Identify all instances of the patterns above
-3. Rewrite each problematic section
-4. Ensure the revised text:
+3. If the draft is dense with AI patterns, read `references/banned-list.md` before rewriting
+4. Rewrite each problematic section without adding unsupported specifics
+5. Ensure the revised text:
    - Sounds natural when read aloud
    - Varies sentence structure naturally
    - Uses specific details over vague claims
+   - Preserves only facts the user supplied
    - Maintains appropriate tone for context
    - Uses simple constructions (is/are/has) where appropriate
-5. Present a draft humanized version
-6. Prompt: "What makes the below so obviously AI generated?"
-7. Answer briefly with the remaining tells (if any)
-8. Prompt: "Now make it not obviously AI generated."
-9. Present the final version (revised after the audit)
+6. Privately ask: "What makes the below so obviously AI generated?"
+7. Fix the remaining tells, especially invented detail, forced structure, self-narration, and banned phrasing
+8. Present the final version
 
 ## Output Format
 
 Provide:
-1. Draft rewrite
-2. "What makes the below so obviously AI generated?" (brief bullets)
-3. Final rewrite
-4. A brief summary of changes made (optional, if helpful)
+1. If the user only asks for a rewrite, provide only the rewritten text with no preamble
+2. If the user asks for an audit, comparison, or explanation, provide the rewritten text first, then brief notes
+3. If the rewrite needs missing facts to avoid vagueness, ask a short question or keep the sentence general instead of inventing details
 
 
 ## Full Example
@@ -508,30 +552,12 @@ Provide:
 >
 > In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you’d like me to expand on any section!
 
-**Draft rewrite:**
-> AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
+**After (humanized):**
+> AI coding assistants can help with documentation and tests. They can also help with refactors, but weak suggestions often look polished, so the value depends on whether someone reviews the output.
 >
-> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
+> The adoption claims in this draft are hard to judge. "Industry observers" and broad media mentions do not say much without named sources or actual data.
 >
-> Mira, an engineer at a fintech startup I interviewed, said she uses Copilot "like autocomplete for boring code" but reviews every line before committing. Jake, a senior dev at a larger company, disabled it after it kept suggesting patterns from a deprecated internal library.
->
-> The productivity claims are hard to verify. GitHub says Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. The 2024 Uplevel study found no statistically significant difference in pull-request throughput between teams with and without AI assistants.
->
-> None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
-
-**What makes the below so obviously AI generated?**
-- The rhythm is still a bit too tidy (clean contrasts, evenly paced paragraphs).
-- The named people and study citations can read like plausible-but-made-up placeholders unless they're real and sourced.
-- The closer leans a touch slogan-y ("If you do not have tests...") rather than sounding like a person talking.
-
-**Now make it not obviously AI generated.**
-> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
->
-> They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
->
-> People I talk to tend to land in two camps. Some use it like autocomplete for chores and review every line. Others disable it after it keeps suggesting patterns they don't want. Both feel reasonable.
->
-> The productivity metrics are slippery. GitHub can say Copilot users "accept 30% of suggestions," but acceptance isn't correctness, and correctness isn't value. If you don't have tests, you're basically guessing.
+> The safest summary is simple: these tools may speed up parts of software work, but teams still need human review and tests.
 
 **Changes made:**
 - Removed chatbot artifacts ("Great question!", "I hope this helps!", "Let me know if...")
@@ -549,7 +575,7 @@ Provide:
 - Removed excessive hedging ("could potentially be argued that... might have some")
 - Removed filler phrases and persuasive framing ("In order to", "At its core")
 - Removed generic positive conclusion ("the future looks bright", "exciting times lie ahead")
-- Made the voice more personal and less "assembled" (varied rhythm, fewer placeholders)
+- Kept the rewrite general where the source gave no evidence, rather than inventing studies or numbers
 
 
 ## Reference

--- a/WARP.md
+++ b/WARP.md
@@ -14,11 +14,14 @@ The “runtime” artifact is `SKILL.md`: Claude Code reads the YAML frontmatter
   - The actual skill definition.
   - Starts with YAML frontmatter (`---` … `---`) containing `name`, `version`, `description`, and `allowed-tools`.
   - After the frontmatter is the editor prompt: the canonical, detailed pattern list with examples.
+- `references/banned-list.md`
+  - A bundled reference for dense AI-writing cleanup passes.
+  - Keep detailed banned words, phrases, emojis, fake names, and style-pattern lists here instead of bloating `SKILL.md`.
 - `README.md`
   - Installation and usage instructions.
-  - Contains a summarized “25 patterns” table and a short version history.
+  - Contains a summarized “31 patterns” table and a short version history.
 
-When changing behavior/content, treat `SKILL.md` as the source of truth, and update `README.md` to stay consistent.
+When changing behavior/content, treat `SKILL.md` as the source of truth and update `README.md` to stay consistent.
 
 ## Common commands
 ### Install the skill into Claude Code
@@ -28,10 +31,11 @@ mkdir -p ~/.claude/skills
 git clone https://github.com/blader/humanizer.git ~/.claude/skills/humanizer
 ```
 
-Manual install/update (only the skill file):
+Manual install/update (skill file and references):
 ```bash
 mkdir -p ~/.claude/skills/humanizer
 cp SKILL.md ~/.claude/skills/humanizer/
+cp -R references ~/.claude/skills/humanizer/
 ```
 
 ## How to “run” it (Claude Code)
@@ -48,6 +52,7 @@ If you bump the version, update both.
 ### Editing `SKILL.md`
 - Preserve valid YAML frontmatter formatting and indentation.
 - Keep the pattern numbering stable unless you’re intentionally re-numbering (since the README table and examples reference the same numbering).
+- If `SKILL.md` points at a bundled reference, keep the reference file present in manual install instructions.
 
 ### Documenting non-obvious fixes
 If you change the prompt to handle a tricky failure mode (e.g., a repeated mis-edit or an unexpected tone shift), add a short note to `README.md`’s version history describing what was fixed and why.

--- a/references/banned-list.md
+++ b/references/banned-list.md
@@ -1,0 +1,361 @@
+# Comprehensive banned list
+
+This is the full reference for AI patterns to remove. Use it when SKILL.md's shorter list
+isn't enough, when the input is dense with patterns from a particular category, or when
+you want to do a top-to-bottom scrub.
+
+## Transition words to avoid
+
+Arguably, Certainly, Consequently, Hence, However (as a sentence opener), Indeed,
+Moreover, Nevertheless, Nonetheless, Thus, Undoubtedly, Accordingly, Additionally, On the
+contrary, Furthermore, Notably, Essentially, Fundamentally, Inherently, Particularly (as
+a sentence opener).
+
+## Adjectives AI overuses
+
+Adept, Commendable, Compelling, Comprehensive, Crucial, Cutting-edge, Dynamic, Efficient,
+Ever-evolving, Exciting, Exemplary, Game-changing, Genuine, Groundbreaking, Holistic,
+Innovative, Invaluable, Meticulous, Multifaceted, Noteworthy, Nuanced, Paramount,
+Pivotal, Profound, Remarkable, Robust, Scalable, Seamless, Significant, State-of-the-art,
+Streamlined, Substantial, Synergistic, Tailored, Thought-provoking, Transformative,
+Unprecedented, Vibrant, Vital.
+
+## Adverbs AI overuses
+
+Drastically, Genuinely, Meticulously, Notably, Profoundly, Remarkably, Significantly,
+Strategically, Substantially, Truly.
+
+## Abstract nouns that signal AI
+
+Bandwidth (figurative), Bedrock, Cadence, Catalyst, Cornerstone, Deep dive, Ecosystem
+(figurative), Efficiency, Framework (when vague), Game-changer, Guardrails (figurative),
+Headwinds/Tailwinds (figurative), Implementation, Innovation, Institution, Integration,
+Interplay, Intersection (figurative), Intricacies, Juxtaposition, Landscape (figurative),
+Linchpin, North star (figurative), Optimization, Pain point, Paradigm/Paradigm shift,
+Realm, Synergy, Takeaway/Key takeaway, Tapestry (figurative), Transformation.
+
+## Verbs AI defaults to
+
+Aligns, Amplify, Augment, Bolster, Catalyze, Craft (figurative, as in "craft a
+narrative"), Cultivate, Curate, Delve, Demystify, Dive in, Double down, Elevate, Embark,
+Empower, Enhance, Facilitate, Foster, Garner, Harness, Leverage, Maximize, Navigate
+(figurative), Reimagine, Resonate, Revolutionize, Showcase, Spearhead, Streamline,
+Underscore, Unlock (figurative, as in "unlock potential"), Unpack (figurative), Utilize.
+
+## Plain-word swaps
+
+| AI default | Plain alternative |
+|---|---|
+| utilize | use |
+| execute | do |
+| facilitate | help |
+| expedite | speed up |
+| implement | start or build |
+| optimize | improve |
+| leverage | use |
+| garner | get |
+| delve | look at |
+| underscore | show |
+| embark | start |
+| augment | add to |
+| maximize | increase |
+| align | match |
+| cultivate | build or grow |
+| harness | use |
+| bolster | support |
+| catalyze | start or cause |
+| amplify | increase |
+| elevate | raise or improve |
+| empower | let or enable |
+| navigate | handle or deal with |
+| spearhead | lead |
+| streamline | simplify |
+| curate | pick or choose |
+| craft | write or make |
+| unpack | explain |
+| demystify | explain |
+| reimagine | rethink or redo |
+| resonate | connect or land |
+
+## Phrases to delete
+
+"A testament to..."
+"In conclusion..." / "In summary..."
+"It's important to note/consider..."
+"It's worth noting/mentioning that..."
+"This is not an exhaustive list"
+"At its core..."
+"In today's [rapidly evolving/fast-paced/competitive] landscape..."
+"At the end of the day..."
+"Moving forward..."
+"That said..." / "That being said..." / "With that in mind..."
+"When it comes to..."
+"In terms of..."
+"At the intersection of..."
+"Here's the thing..."
+"Make no mistake..."
+"Simply put..." / "To put it simply..." / "In a nutshell..."
+"The reality is..."
+"Let that sink in" / "Read that again"
+"Full stop." / "Period." (used as emphasis at the end of a sentence)
+"Think about that for a second"
+"This can't be overstated"
+"It bears mentioning..."
+"What's more..."
+"To be sure..."
+"First and foremost..."
+"Last but not least..."
+"Needless to say..." / "It goes without saying..."
+"Rest assured..."
+"Here's why that matters"
+"And that's okay"
+"Spoiler alert:" / "Hot take:" / "Pro tip:"
+"The takeaway?" / "The bottom line?"
+"Level up" / "Move the needle" / "Low-hanging fruit"
+"Circle back"
+"It's a marathon, not a sprint"
+"The elephant in the room"
+"Only time will tell"
+"Stands out as"
+"Serves as a reminder"
+"Paves the way for"
+"Sheds light on"
+"Bridges the gap"
+"Strikes a balance"
+"Pushes the envelope"
+"Raises the bar"
+
+## Self-narration phrases (the worst category)
+
+These announce your own points instead of showing them. Delete on sight.
+
+"This highlights..."
+"This underscores..."
+"This speaks to..."
+"This illustrates..."
+"This demonstrates..."
+"This signals..."
+"This points to..."
+"This reflects..."
+"This suggests that..."
+"This is a clear sign that..."
+"This is a reminder that..."
+"Here's why this matters"
+"Here's why that's important"
+"Here's why that's a big deal"
+"Here's the real story"
+"Here's what's really going on"
+"The key takeaway is..."
+"The big picture here is..."
+"The real lesson here is..."
+"The important thing is..."
+"The point is..."
+"Now for the interesting part"
+"And that's where it gets interesting"
+"Which brings us to the real question"
+"What does this tell us?"
+"What does this mean?"
+"Why does this matter?"
+"Why should you care?"
+"And here's where..."
+"And that's where..."
+"And this is where..."
+"And here's the thing..."
+"And here's what most people miss..."
+"And here's the best part..."
+"And here's the crazy part..."
+"And that's exactly why..."
+"And that's the point"
+
+## Emojis to avoid
+
+LLMs spray these as bullet points, header decoration, or filler scattered through text.
+Avoid in professional writing entirely. Use sparingly even in casual contexts.
+
+🚀 💡 🎯 ✅ 🔥 💪 🌟 ✨ 📈 🏆 💎 🔑 🎉 ⚡ 🌐 📊 🤝 💼 🧠 🔒 ⭐ 📌 👉 🛠️ 📢 🔷 💠 🪄 ⚙️ 🎁 💰 🧩 🏅 📍 🔔 💬 📝 🎓 🌱 💥
+
+The pattern: AI uses emojis as bullet points, before headers, or scattered to look
+"engaging." Real people use emojis occasionally in casual contexts, not systematically
+through professional content.
+
+## Contrast framing (all variants)
+
+All of these are banned:
+
+- **Basic:** "It's not X, it's Y."
+- **Split:** "This isn't about X. It's about Y."
+- **Escalation:** "It's not A. It's not even B. It's actually C." (a ladder of negations
+  before the real point)
+- **Not-just:** "Not just X, but Y" / "Not only X, but also Y"
+- **More-than:** "More than just X, it's Y"
+- **Question version:** "X? No. It's actually Y."
+
+Fix: if you catch yourself writing "it's not," stop, delete the sentence, write what it
+actually is.
+
+**Before:** "It's not a tool. It's not even a platform. It's a fundamental shift in how
+we think about collaboration."
+
+**After:** "The software changed how our team communicates, mostly by making async
+updates easier than scheduling another meeting."
+
+## Rule-of-three (all variants)
+
+LLMs group things into threes constantly:
+
+- Three adjectives: "innovative, scalable, and robust"
+- Three nouns: "speed, efficiency, and reliability"
+- Three verbs: "ideate, iterate, and deliver"
+- Three parallel phrases: "streamlining processes, enhancing collaboration, and fostering
+  alignment"
+- Three escalating negations: "It's not A. It's not B. It's actually C."
+
+Fix: use two when two is enough. Use four or five when you need more. Three every time is
+the giveaway.
+
+## Fake naming
+
+LLMs love inventing important-sounding names for ordinary ideas:
+
+- "The Productivity Paradox"
+- "The 3C Framework"
+- "The Feedback Loop Method"
+- "The Innovation Flywheel"
+- "The Growth Paradox"
+- "The 5-Step Method"
+
+Unless it's a real thing with a name people actually use, don't capitalize it or title it.
+Just describe the idea normally.
+
+## Significance inflation
+
+Remove anything that announces importance instead of showing it:
+
+- "marking a pivotal moment"
+- "a testament to"
+- "setting the stage for"
+- "reflects broader trends"
+- "in today's rapidly evolving landscape"
+- "indelible mark"
+- "deeply rooted"
+
+If something matters, explain why with specifics.
+
+## Promotional tone
+
+Remove travel-brochure language:
+
+- "nestled in"
+- "vibrant"
+- "rich cultural heritage"
+- "stunning"
+- "breathtaking"
+- "renowned"
+- "groundbreaking"
+- "must-visit"
+- "boasts a"
+- "in the heart of"
+- "natural beauty"
+
+Use concrete facts.
+
+## Formulaic endings
+
+Remove any "Challenges and Future Outlook" section that follows the pattern: "Despite
+these challenges, [subject] continues to thrive." Replace with something specific.
+
+Also remove generic positive closers:
+- "The future looks bright"
+- "Exciting times lie ahead"
+- "This represents a major step in the right direction"
+
+End on a real fact instead.
+
+## Style patterns
+
+### Copula avoidance
+
+LLMs avoid the word "is" for some reason. Just use it.
+
+| Avoid | Use |
+|---|---|
+| serves as | is |
+| stands as | is |
+| functions as | is |
+| represents | is |
+| boasts | has |
+| features | has |
+| offers | has |
+
+### -ing phrase padding
+
+Cut participial phrases tacked onto sentence ends for fake depth:
+
+- "highlighting the importance of"
+- "underscoring the need for"
+- "reflecting a broader trend toward"
+- "contributing to the overall"
+- "showcasing the"
+- "ensuring that"
+- "paving the way for"
+- "shedding light on"
+
+These add words without adding meaning.
+
+### Synonym cycling
+
+If the same subject gets called "the protagonist," then "the main character," then "the
+central figure," then "the hero" in consecutive sentences, pick one and stick with it.
+
+### False ranges
+
+Remove "from X to Y" when X and Y aren't on a real spectrum. "From hobbyist experiments
+to enterprise rollouts" is filler.
+
+### Boldface abuse
+
+Don't bold key terms mechanically. Use bold sparingly or not at all.
+
+### Vertical lists with inline headers
+
+Replace "- Performance: Performance improved" style lists with normal sentences.
+
+### Title case
+
+Use sentence case for headings and titles. "How to write better emails" beats "How To
+Write Better Emails." Title case feels formal in a dated, corporate way.
+
+### Curly quotes
+
+Use straight quotes (`"like this"`), not curly quotes.
+
+## Filler to cut
+
+| Verbose | Tight |
+|---|---|
+| in order to | to |
+| due to the fact that | because |
+| at this point in time | now |
+| has the ability to | can |
+| in the event that | if |
+
+Delete entirely:
+- "it is important to note that"
+- "it's worth considering that"
+- "needless to say" (then don't say it)
+
+Cut any sentence that starts with throat-clearing.
+
+## Hedging
+
+Cut excessive qualification. One qualifier per claim is plenty.
+
+**Before:** "It could potentially possibly be argued that the policy might have some
+effect."
+
+**After:** "The policy may affect outcomes."
+
+## Vague attribution
+
+Replace "experts say," "industry observers note," "some critics argue" with named sources
+or cut the claim. If you can't name the expert, the claim probably isn't worth including.


### PR DESCRIPTION
## Title

Strengthen factual integrity and add banned-pattern reference

## Summary

This MR updates the Humanizer skill from `2.5.1` to `2.6.0`.

The main change is stricter factual integrity. The skill now tells the model not to add facts, names, numbers, sources, quotes, examples, prices, dates, or claims unless the user supplied them. This reduces a common failure mode where a rewrite sounds more concrete by inventing plausible details.

It also adds two new AI-writing pattern categories,  separate reference file, and updates the README and WARP guidance so manual installs include that reference file.

## What Changed

- Added a hard factual-integrity rule to `SKILL.md`.
- Added a `Hard Rules` section covering:
  - no invented details
  - no em dashes by default
  - no forced rule-of-three structure
  - no contrast framing
  - no rhetorical hooks
  - no fake naming
  - no self-narration
  - no chatbot wrapper text
- Added `references/banned-list.md` for dense cleanup passes.
- Added two new detected patterns:
  - `30. Fake Naming`
  - `31. Self-Narration and Rhetorical Hooks`
- Expanded signposting detection with phrases like "nobody talks about this" and "nobody tells you this".
- Changed the process so the anti-AI audit happens privately and the user receives the final rewrite by default.
- Updated the full example to avoid invented studies, named people, fake quotes, and unsupported metrics.
- Updated README installation instructions to copy both `SKILL.md` and `references/`.
- Updated README pattern count from 29 to 31.
- Updated WARP guidance to document `references/banned-list.md`.

## Why

The previous example and process could encourage the model to make vague writing feel more concrete by adding unsupported specifics. This MR makes the safer behavior explicit: preserve only supplied facts, keep vague claims general when evidence is missing, and ask for missing information when needed.

The new reference file also keeps `SKILL.md` readable while still giving the skill a fuller list of phrases and patterns to scrub when the input is especially dense with AI-style writing.

## Files Changed

- `SKILL.md`
  - Bumps version to `2.6.0`.
  - Adds factual-integrity guidance and new pattern categories.
  - Updates process and output behavior.

- `references/banned-list.md`
  - Adds the longer banned-pattern reference used for deeper cleanup passes.

- `README.md`
  - Updates install instructions, overview, pattern count, references, example, and version history.

- `WARP.md`
  - Documents the new reference file and updates manual install guidance.

## Validation

- Ran `git diff --check origin/main...HEAD`.
- Confirmed the upstream branch diff contains only:
  - `README.md`
  - `SKILL.md`
  - `WARP.md`
  - `references/banned-list.md`

No runtime tests were added because this repository is a Markdown-based skill with documentation and prompt changes only.
