### PR TITLE
docs: clarify shared install path for OpenCode compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ mkdir -p ~/.config/opencode/skills/humanizer
 cp SKILL.md ~/.config/opencode/skills/humanizer/
 ```
 
-> **Note:** OpenCode also scans `~/.claude/skills/` for compatibility, so a single clone into `~/.claude/skills/humanizer/` works for both tools.
+> **Note:** OpenCode also scans `~/.claude/skills/` for compatibility, so if you use both tools, a single clone into `~/.claude/skills/humanizer/` is enough.
 
 ## Usage
 


### PR DESCRIPTION
Clarifies that users who rely on both Claude Code and OpenCode can use a single shared install path.