### PR TITLE
Narrow Section 26 hyphen rule to drop only predicate-position cases

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -408,13 +408,13 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 **Words to watch:** third-party, cross-functional, client-facing, data-driven, decision-making, well-known, high-quality, real-time, long-term, end-to-end
 
-**Problem:** AI hyphenates common word pairs with perfect consistency. Humans rarely hyphenate these uniformly, and when they do, it's inconsistent. Less common or technical compound modifiers are fine to hyphenate.
+**Problem:** AI hyphenates these uniformly, including in predicate position (`the report is high-quality`). Humans hyphenate inconsistently — typically only when the compound is attributive (`a high-quality report`) and often dropping the hyphen otherwise (`the report is high quality`). Keep attributive-position hyphens; drop them when the compound follows the noun.
 
 **Before:**
-> The cross-functional team delivered a high-quality, data-driven report on our client-facing tools. Their decision-making process was well-known for being thorough and detail-oriented.
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
 
 **After:**
-> The cross functional team delivered a high quality, data driven report on our client facing tools. Their decision making process was known for being thorough and detail oriented.
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
 
 
 ### 27. Persuasive Authority Tropes


### PR DESCRIPTION
## Narrow Section 26 hyphen rule to drop only predicate-position cases

### The problem

Section 26 currently tells writers to strip hyphens from compound modifiers like `well-known`, `high-quality`, `real-time`, `data-driven`, `client-facing` *uniformly*. The Before/After example demonstrates exactly that — every hyphenated compound modifier loses its hyphen, regardless of position.

That produces ungrammatical English in attributive position:

- `a high-quality report` is correct (standard attributive hyphenation)
- `a high quality report` is wrong

A user (or an automated tool) applying the rule literally to text that uses standard attributive hyphenation will end up with grammatically incorrect prose.

### What the actual AI tell is

The pattern that signals LLM output isn't *any* hyphenation of compound modifiers — it's *uniform* hyphenation that doesn't distinguish position:

- **AI:** `the report is high-quality` and `a high-quality report` (hyphen in both)
- **Human:** `the report is high quality` but `a high-quality report` (hyphen only in attributive)

Humans hyphenate inconsistently — typically only when the compound is *attributive* (sits before the noun it modifies) and often drop the hyphen in predicate position (after a linking verb).

### Proposed change

Reword the Problem statement to spell out the attributive-vs-predicate distinction:

> **Problem:** AI hyphenates these uniformly, including in predicate position (`the report is high-quality`). Humans hyphenate inconsistently — typically only when the compound is attributive (`a high-quality report`) and often dropping the hyphen otherwise (`the report is high quality`). Keep attributive-position hyphens; drop them when the compound follows the noun.

Rework the Before/After so the same compound modifiers appear in both positions, and only the predicate-position hyphens get dropped:

**Before:**
> The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.

**After:**
> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.

This makes the contrast actually illustrate the human-vs-LLM pattern: the attributive uses keep their hyphens (correct English); only the predicate uses lose them (where the AI tell lives).

### Context

This was caught during an external code review on a private repo where this skill is vendored as a dependency. The reviewer (independent of either the vendor or the maintainer) flagged the over-broad rule because it would corrupt prose if humanizer is applied as instructed to writing that uses standard attributive hyphenation.

Happy to adjust the wording or examples if you'd prefer a different framing — the main concern is that the rule as written can produce ungrammatical output.
