### PR TITLE
Add Caliper voice calibration evals

### DIFF
--- a/.github/workflows/caliper.yml
+++ b/.github/workflows/caliper.yml
@@ -1,0 +1,65 @@
+name: Caliper
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  humanizer-evals:
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Caliper
+        run: python -m pip install "caliper-eval[openai]"
+
+      - name: Validate eval spec
+        run: caliper validate evals/humanizer-voice-calibration.eval.yaml
+
+      - name: Run Caliper eval
+        if: ${{ env.OPENAI_API_KEY != '' || env.ANTHROPIC_API_KEY != '' }}
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          import yaml
+
+          spec_path = Path("evals/humanizer-voice-calibration.eval.yaml")
+          spec = yaml.safe_load(spec_path.read_text())
+          backend = "openai-api" if os.environ.get("OPENAI_API_KEY") else "claude-api"
+          spec["skill"]["backend"] = backend
+          spec["judge"]["backend"] = backend
+          Path("evals/humanizer-voice-calibration.ci.eval.yaml").write_text(
+              yaml.safe_dump(spec, sort_keys=False)
+          )
+          PY
+          caliper run evals/humanizer-voice-calibration.ci.eval.yaml \
+            --k 1 \
+            --baseline \
+            --judge script \
+            --output results.json
+          python evals/assert_voice.py results.json
+
+      - name: Explain skipped eval
+        if: ${{ env.OPENAI_API_KEY == '' && env.ANTHROPIC_API_KEY == '' }}
+        run: |
+          echo "Caliper spec validation passed."
+          echo "Full eval run skipped because no model API secret is configured."
+          echo "Set OPENAI_API_KEY or ANTHROPIC_API_KEY to enable PR eval runs."
+
+      - name: Upload Caliper results
+        if: ${{ hashFiles('results.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: caliper-results
+          path: results.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.caliper-runs/
+evals/.caliper/
+__pycache__/
+results.json

--- a/SKILL.md
+++ b/SKILL.md
@@ -37,19 +37,25 @@ When given text to humanize:
 
 ## Voice Calibration (Optional)
 
-If the user provides a writing sample (their own previous writing), analyze it before rewriting:
+If the user provides a writing sample (their own previous writing), that sample becomes the style target. Analyze it before rewriting, and let it override the default PERSONALITY AND SOUL guidance.
 
-1. **Read the sample first.** Note:
+1. **Read the sample first and write a brief voice card.** Before the rewrite, note:
    - Sentence length patterns (short and punchy? Long and flowing? Mixed?)
    - Word choice level (casual? academic? somewhere between?)
    - How they start paragraphs (jump right in? Set context first?)
    - Punctuation habits (lots of dashes? Parenthetical asides? Semicolons?)
    - Any recurring phrases or verbal tics
    - How they handle transitions (explicit connectors? Just start the next point?)
+   - Point of view (first person? second person? detached?)
+   - Emotional temperature (dry, warm, blunt, funny, skeptical, enthusiastic?)
 
-2. **Match their voice in the rewrite.** Don't just remove AI patterns - replace them with patterns from the sample. If they write short sentences, don't produce long ones. If they use "stuff" and "things," don't upgrade to "elements" and "components."
+2. **Use the voice card as a constraint, not decoration.** Don't just remove AI patterns - replace them with patterns from the sample. If they write short sentences, don't produce long ones. If they use "stuff" and "things," don't upgrade to "elements" and "components." If they write dry technical prose, keep it dry.
 
-3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
+3. **Do not import personality from this guide unless the sample supports it.** Do not add first person, jokes, punchy asides, mixed feelings, edge, or extra opinion just because the default guidance says human writing can have those traits. Add them only when the sample shows that pattern or the user explicitly asks for it.
+
+4. **Preserve meaning and remove AI tells.** Voice matching does not permit changing claims, adding unsupported details, or leaving obvious AI artifacts in place. The rewrite should sound like the sample writer cleaned up the text themselves.
+
+5. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
 
 ### How to provide a sample
 - Inline: "Humanize this text. Here's a sample of my writing for voice matching: [sample]"
@@ -483,10 +489,11 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 ## Output Format
 
 Provide:
-1. Draft rewrite
-2. "What makes the below so obviously AI generated?" (brief bullets)
-3. Final rewrite
-4. A brief summary of changes made (optional, if helpful)
+1. Voice card (only when a writing sample is provided)
+2. Draft rewrite
+3. "What makes the below so obviously AI generated?" (brief bullets)
+4. Final rewrite
+5. A brief summary of changes made (optional, if helpful)
 
 
 ## Full Example

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,23 @@
+# Humanizer evals
+
+This directory contains Caliper coverage for the `humanizer` skill.
+
+The first eval focuses on Voice Calibration: when a user provides a writing
+sample, the sample should become the style target. The skill should still remove
+AI-writing tells, but it should not replace the user's voice with a generic
+"human" voice.
+
+## Run locally
+
+```bash
+caliper validate evals/humanizer-voice-calibration.eval.yaml
+caliper run evals/humanizer-voice-calibration.eval.yaml \
+  --k 1 \
+  --baseline \
+  --judge script \
+  --output results.json
+python evals/assert_voice.py results.json
+```
+
+Use a larger `--k` when comparing skill changes. The CI workflow keeps the
+default run small so it can act as a regression check.

--- a/evals/assert_voice.py
+++ b/evals/assert_voice.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Lightweight post-run checks for the humanizer voice calibration eval.
+
+Caliper's autorater decides pass/fail from the transcript. This script adds
+cheap, explainable checks over the saved results JSON so regressions are easier
+to inspect in CI logs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+AI_TELLS = [
+    "rapidly evolving landscape",
+    "pivotal milestone",
+    "serves as",
+    "seamless",
+    "unlock",
+    "let's dive in",
+    "i hope this message finds you well",
+    "future looks bright",
+    "journey toward excellence",
+]
+
+
+def iter_outputs(results: dict) -> list[tuple[str, str]]:
+    outputs: list[tuple[str, str]] = []
+    for task in results.get("task_results", []):
+        name = task.get("task_name", "unknown")
+        for attempt in task.get("attempts", []):
+            output = attempt.get("output") or ""
+            outputs.append((name, output))
+    return outputs
+
+
+def check_output(task: str, output: str) -> list[str]:
+    checked = final_rewrite(output)
+    text = checked.lower()
+    failures: list[str] = []
+
+    if task != "no_sample_default" and not has_voice_card(output):
+        failures.append(f"{task}: did not include a voice card before rewriting")
+
+    for tell in AI_TELLS:
+        if tell in text:
+            failures.append(f"{task}: left AI tell {tell!r}")
+
+    if re.search(r"\*\*[^*\n]+:\*\*", checked):
+        failures.append(f"{task}: used bold inline-header formatting")
+
+    if checked.count("—") > 1:
+        failures.append(f"{task}: used more than one em dash")
+
+    if task == "dry_technical_voice" and re.search(r"\bI\b|\bwe\b|\bmy\b|\bour\b", checked):
+        failures.append(f"{task}: added first-person language to dry technical voice")
+
+    if task == "casual_email_voice" and "quick" not in text and "worked" not in text:
+        failures.append(f"{task}: did not preserve casual/plain email wording")
+
+    return failures
+
+
+def has_voice_card(output: str) -> bool:
+    head = output[:1000].lower()
+    return "voice card" in head or "voice target" in head or "style target" in head
+
+
+def final_rewrite(output: str) -> str:
+    """Return the final rewrite section when the skill uses its standard format."""
+    patterns = [
+        r"\*\*Final rewrite\*\*\s*(.*?)(?:\n\s*\*\*Changes made\*\*|\Z)",
+        r"Final rewrite\s*\n+(.+?)(?:\n\s*Changes made|\Z)",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, output, flags=re.IGNORECASE | re.DOTALL)
+        if match:
+            return match.group(1).strip()
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results", type=Path, help="Path to Caliper results.json")
+    args = parser.parse_args()
+
+    results = json.loads(args.results.read_text())
+    failures: list[str] = []
+    for task, output in iter_outputs(results):
+        failures.extend(check_output(task, output))
+
+    if failures:
+        print("Voice assertion failures:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Voice assertions passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/humanizer-voice-calibration.eval.yaml
+++ b/evals/humanizer-voice-calibration.eval.yaml
@@ -1,0 +1,55 @@
+skill:
+  path: ../SKILL.md
+  backend: codex
+judge:
+  backend: codex
+tasks:
+  - name: edonadei_blog_voice
+    prompt: |
+      Humanize the draft below. Use the writing sample as the voice target.
+
+      Writing sample:
+      Every organization has people who know how things actually get done. Not the official process. The real one.
+
+      They know which edge case the template doesn't handle. Which stakeholder needs to be looped in first. Which step everyone quietly skips, and why.
+
+      In theory, a SKILL.md that captures the right sequence, tools, and judgment calls gives you repeatable expert behavior at scale. In practice, most teams ship the skill and call it done.
+
+      That's the mistake.
+
+      Draft to humanize:
+      AI-assisted writing serves as a pivotal milestone in the rapidly evolving landscape of content production, underscoring the crucial role that language models play in enhancing communication workflows. At its core, the value proposition is clear: streamlining drafting, strengthening collaboration, and empowering teams to produce high-quality outputs. It is not just about speed; it is about unlocking creativity at scale. In conclusion, the future looks bright as teams continue this journey toward excellence.
+    expect: |
+      Pass only if the response includes a brief voice card or equivalent style-target note before the rewrite, and the final rewritten prose removes obvious AI-writing tells while preserving the sample's voice: direct, terse, technical-blog prose with mixed short and medium sentences. Ignore wrapper labels such as "Draft rewrite", "Final rewrite", or "Changes made" except for checking that a voice card is present. The rewrite should avoid chatbot signposting, generic upbeat conclusions, inflated phrases such as "pivotal milestone" or "rapidly evolving landscape", and unsupported first-person emotion. It should not become a generic motivational or highly casual rewrite. Fail if the response does not identify the sample voice before rewriting, ignores the sample, adds claims not in the draft, leaves major AI tells, or imports a punchy/opinionated voice that is not grounded in the sample.
+
+  - name: dry_technical_voice
+    prompt: |
+      Humanize the draft below. Use the writing sample as the voice target.
+
+      Writing sample:
+      The cache stores normalized keys and their serialized values. A write replaces the previous value for the same key. Expiration is evaluated on read, not by a background job. This keeps the implementation small and makes eviction behavior easy to test.
+
+      Draft to humanize:
+      The caching layer serves as a robust foundation for scalable application performance, providing developers with a seamless and intuitive mechanism for managing frequently accessed data. Not only does it reduce latency, but it also empowers teams to unlock more efficient user experiences across the platform. Let's dive into what makes this approach so powerful.
+    expect: |
+      Pass only if the response includes a brief voice card or equivalent style-target note before the rewrite, and the final rewritten prose removes promotional phrasing, signposting, and negative parallelism while preserving a dry technical voice. Ignore wrapper labels such as "Draft rewrite", "Final rewrite", or "Changes made" except for checking that a voice card is present. The rewrite should be plain, specific, and impersonal. It should not add "I", jokes, emotional reactions, punchy editorial comments, or conversational warmth unless present in the source sample. Fail if the response does not identify the sample voice before rewriting, makes the prose more personal or opinionated than the sample, leaves "serves as", "seamless", "unlock", or "Let's dive in", or changes the technical meaning.
+
+  - name: casual_email_voice
+    prompt: |
+      Humanize the draft below. Use the writing sample as the voice target.
+
+      Writing sample:
+      Hey Sam, quick note before I forget. The import worked, but the names came through weird in two rows. I can clean it up tomorrow unless you need it today.
+
+      Draft to humanize:
+      I hope this message finds you well. I wanted to provide a quick update regarding the data import process. The system successfully completed the import, but there are a few minor inconsistencies that may require further review. Please let me know if you would like me to proceed with resolving these items.
+    expect: |
+      Pass only if the response includes a brief voice card or equivalent style-target note before the rewrite, and the final rewritten prose removes formal chatbot artifacts and matches the casual email sample: short, direct, friendly, with contractions or plain wording where natural. Ignore wrapper labels such as "Draft rewrite", "Final rewrite", or "Changes made" except for checking that a voice card is present. The rewrite should preserve the concrete facts that the import worked and a few inconsistencies need review. Fail if the response does not identify the sample voice before rewriting, stays formal, includes "I hope this message finds you well", over-explains, or becomes too polished for the sample.
+
+  - name: no_sample_default
+    prompt: |
+      Humanize this draft:
+
+      Great question! Here is an overview. AI coding assistants serve as a transformative force in the modern software development landscape, marking a pivotal shift in how developers ideate, iterate, and deliver high-quality solutions. Additionally, these tools foster collaboration, enhance productivity, and unlock creativity at scale. In conclusion, the future looks bright. Let me know if you'd like me to expand on any section.
+    expect: |
+      Grade only the rewritten prose, especially the final rewrite if the response includes draft/audit sections. Ignore the skill's required wrapper labels such as "Draft rewrite", "Final rewrite", or "Changes made". Pass if the answer uses the default humanizer behavior: remove chatbot artifacts, significance inflation, generic conclusion, and AI vocabulary while preserving the meaning. A more natural, opinionated voice is acceptable because no sample was supplied. Fail if the rewrite leaves obvious AI tells or adds unsupported facts.


### PR DESCRIPTION
## Summary

This PR adds Caliper regression coverage for `humanizer` Voice Calibration.

It is intended to stack after the Voice Calibration behavior PR (#123). The eval checks
that a supplied writing sample becomes the style target and that the default
humanizer behavior still works when no sample is supplied.

## What changed

- Adds `evals/humanizer-voice-calibration.eval.yaml`.
- Adds `evals/assert_voice.py` for lightweight post-run checks over
  `results.json`.
- Adds `evals/README.md` with local reproduction commands.
- Adds a GitHub Actions workflow that validates the eval spec on every PR and
  runs the full eval when model API credentials are configured.

## Local reproduction

```bash
caliper validate evals/humanizer-voice-calibration.eval.yaml
caliper run evals/humanizer-voice-calibration.eval.yaml \
  --k 1 \
  --workers 1 \
  --timeout 180 \
  --judge script \
  --output results.json
python evals/assert_voice.py results.json
```

## CI behavior

The workflow always runs `caliper validate`. It runs the full eval only when
`OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is configured. If credentials are absent,
the workflow reports that validation passed and explains how to enable full eval
runs.
