### PR TITLE
Add pattern 31: reference-markup artifacts

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -483,6 +483,19 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 > This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
 
 
+### 31. Reference-Markup Artifacts
+
+**Signs to watch:** turn0search0, citeturn0search1, :contentReference[oaicite:0], oai_citation, [web:1], ?utm_source=chatgpt.com, &referrer=grok.com — citation or tracking tokens left in after pasting straight from a chat UI.
+
+**Problem:** These are a model's internal citation/tracking tokens, not prose. They never occur in human writing, so finding one is near-conclusive evidence of unedited AI output. Strip the token; if it stood in for a real source, replace it with a real citation or link.
+
+**Before:**
+> The reform passed in 2019 citeturn0search3 and reshaped the agency. See the announcement (https://example.org/reform?utm_source=chatgpt.com).
+
+**After:**
+> The reform passed in 2019 and reshaped the agency. See the announcement (https://example.org/reform).
+
+
 ## DETECTION GUIDANCE
 
 ### What NOT to flag (false positives)


### PR DESCRIPTION
Resubmit of the single high-signal pattern you flagged on #112 — just the reference-markup artifacts, no overlap with #21/#23/#25.

Adds **§31 Reference-Markup Artifacts**: citation/tracking tokens that leak in when text is pasted straight out of a chat UI without scrubbing (`turn0search0`, `citeturn0search1`, `:contentReference[oaicite:0]`, `oai_citation`, `[web:1]`, `?utm_source=chatgpt.com`, `&referrer=grok.com`). These never occur in human prose, so a hit is near-conclusive evidence of unedited AI output.

Scope is deliberately minimal: SKILL.md only, one pattern, +13 lines, slotted after §30 and before the Detection Guidance section. No README/version changes.

Source: [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) — "Markup" and "Citations" sections.