### PR TITLE
Update humanizer to v2.8.0 with heading and list patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 |---|---------|--------|-------|
 | 14 | **Em/en dashes** | "institutions—not the people—yet this continues—" | Cut them: periods, commas, colons, or parentheses |
 | 15 | **Boldface overuse** | "**OKRs**, **KPIs**, **BMC**" | "OKRs, KPIs, BMC" |
-| 16 | **Inline-header lists** | "**Performance:** Performance improved" | Convert to prose |
+| 16 | **Inline-header lists** | "**Performance:** Performance improved", "*Cognitive Noise*: ..." | Convert to prose or plain bullets |
 | 17 | **Title Case Headings** | "Strategic Negotiations And Partnerships" | "Strategic negotiations and partnerships" |
 | 18 | **Emojis** | "🚀 Launch Phase: 💡 Key Insight:" | Remove emojis |
 | 19 | **Curly quotes** | `said “the project”` | `said “the project”` |
@@ -128,6 +128,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 28 | **Signposting announcements** | "Let's dive in", "Here's what you need to know" | Start with the content |
 | 29 | **Fragmented headers** | "## Performance" + "Speed matters." | Let the heading do the work |
 | 30 | **Diff-anchored writing** | "This function was added to replace..." | Describe what it does, not what changed |
+| 31 | **Two-part/parenthetical headings** | "The Cost: Dependencies", "Readability (The Rule)" | Pick exactly one direct, clean title |
 
 ### Communication Patterns
 
@@ -180,6 +181,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.8.0** - Added pattern #31 (two-part or parenthetical headings); expanded #16 to cover italicized/bolded conceptual descriptors (e.g. `*Cognitive Noise*: ...`) and discourage excessive vertical lists with inline headers. 31 patterns total.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.
 - **2.5.1** - Added a passive-voice / subjectless-fragment rule, raising the total to 29 patterns

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.7.0
+version: 2.8.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -288,15 +288,20 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 
 ### 16. Inline-Header Vertical Lists
 
-**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+**Problem:** AI outputs lists where items start with bolded headers or italicized conceptual descriptors followed by colons (e.g., `- **Performance**: ...` or `- *Cognitive Noise*: ...`). Humans write paragraphs or simple, plain bullet points, using conceptual headings in lists far less frequently (about 1/5th as often as AI).
 
 **Before:**
 > - **User Experience:** The user experience has been significantly improved with a new interface.
 > - **Performance:** Performance has been enhanced through optimized algorithms.
 > - **Security:** Security has been strengthened with end-to-end encryption.
+> 
+> * *Cognitive Noise*: Lifetimes (`'a`) are everywhere.
+> * *Type Complexity*: TypeScript trends toward type gymnastics.
 
 **After:**
 > The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+> 
+> In Rust, explicit lifetimes (`'a`) are required everywhere, increasing cognitive noise. In TypeScript, the type system often trends toward complex type gymnastics.
 
 
 ### 17. Title Case in Headings
@@ -481,6 +486,19 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 
 **After:**
 > This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
+### 31. Two-Part, Coloned, or Parenthetical Headings
+
+**Problem:** AI loves to write two-part titles or add parenthetical descriptors to headings (e.g. `The Turning Point: The Cost of Dependencies` or `Readability and Maintainability (The "15-Minute Rule")`). Humans pick exactly one direct, clean title per section.
+
+**Before:**
+> ## The Turning Point: The Cost of Dependencies
+> ### Readability and Maintainability (The "15-Minute Rule")
+> #### Baseline Cold Start (Version Flag Check)
+
+**After:**
+> ## The Cost of Dependencies
+> ### Readability
+> #### Baseline Cold Start
 
 
 ## DETECTION GUIDANCE


### PR DESCRIPTION
This PR updates the humanizer skill to version 2.8.0, adding patterns to clean up two-part/parenthetical headings and concept-descriptor lists.