### PR TITLE
Update README with installation note for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ mkdir -p ~/.claude/skills/humanizer
 cp SKILL.md ~/.claude/skills/humanizer/
 ```
 
+> **Important:** If Claude Code was open during installation, close it completely and reopen it before using `/humanizer`. Otherwise, the skill may not appear right away.
+
 ### OpenCode
 
 Clone directly into OpenCode's skills directory:


### PR DESCRIPTION
Re-does #89 against current main (2.7.0).

Adds a note under the Claude Code installation section telling users to close and reopen Claude Code after installing the skill, so `/humanizer` shows up right away.

The original PR had the note inserted directly above `### OpenCode` with no blank line between them, which broke the heading rendering. This version has a blank line on both sides of the blockquote so the heading parses correctly.