### PR TITLE
Add Claude Code plugin and marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "humanizer",
+  "owner": {
+    "name": "Siqi Chen",
+    "url": "https://github.com/blader"
+  },
+  "description": "Marketplace for the Humanizer skill — removes signs of AI-generated writing from text.",
+  "plugins": [
+    {
+      "name": "humanizer",
+      "source": "./",
+      "description": "Remove signs of AI-generated writing from text, making it sound more natural and human. Based on Wikipedia's \"Signs of AI writing\" guide."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "humanizer",
+  "description": "Remove signs of AI-generated writing from text, making it sound more natural and human. Based on Wikipedia's \"Signs of AI writing\" guide.",
+  "version": "2.7.0",
+  "author": {
+    "name": "Siqi Chen",
+    "url": "https://github.com/blader"
+  },
+  "homepage": "https://github.com/blader/humanizer",
+  "repository": "https://github.com/blader/humanizer",
+  "license": "MIT",
+  "keywords": [
+    "writing",
+    "editing",
+    "ai-detection",
+    "humanizer",
+    "skill"
+  ],
+  "skills": [
+    "./"
+  ]
+}

--- a/.omc/state/agent-replay-5c2c5924-fa8f-46fb-ad74-5912a654b72a.jsonl
+++ b/.omc/state/agent-replay-5c2c5924-fa8f-46fb-ad74-5912a654b72a.jsonl
@@ -1,0 +1,2 @@
+{"t":0,"agent":"ad00d78","agent_type":"general-purpose","event":"agent_start","parent_mode":"none"}
+{"t":0,"agent":"ad00d78","agent_type":"general-purpose","event":"agent_stop","success":true,"duration_ms":45754}

--- a/.omc/state/mission-state.json
+++ b/.omc/state/mission-state.json
@@ -1,0 +1,53 @@
+{
+  "updatedAt": "2026-05-31T06:11:32.254Z",
+  "missions": [
+    {
+      "id": "session:5c2c5924-fa8f-46fb-ad74-5912a654b72a:none",
+      "source": "session",
+      "name": "none",
+      "objective": "Session mission",
+      "createdAt": "2026-05-31T06:10:46.500Z",
+      "updatedAt": "2026-05-31T06:11:32.254Z",
+      "status": "done",
+      "workerCount": 1,
+      "taskCounts": {
+        "total": 1,
+        "pending": 0,
+        "blocked": 0,
+        "inProgress": 0,
+        "completed": 1,
+        "failed": 0
+      },
+      "agents": [
+        {
+          "name": "general-purpose:ad00d78",
+          "role": "general-purpose",
+          "ownership": "ad00d789e1323bb74",
+          "status": "done",
+          "currentStep": null,
+          "latestUpdate": "completed",
+          "completedSummary": null,
+          "updatedAt": "2026-05-31T06:11:32.254Z"
+        }
+      ],
+      "timeline": [
+        {
+          "id": "session-start:ad00d789e1323bb74:2026-05-31T06:10:46.500Z",
+          "at": "2026-05-31T06:10:46.500Z",
+          "kind": "update",
+          "agent": "general-purpose:ad00d78",
+          "detail": "started general-purpose:ad00d78",
+          "sourceKey": "session-start:ad00d789e1323bb74"
+        },
+        {
+          "id": "session-stop:ad00d789e1323bb74:2026-05-31T06:11:32.254Z",
+          "at": "2026-05-31T06:11:32.254Z",
+          "kind": "completion",
+          "agent": "general-purpose:ad00d78",
+          "detail": "completed",
+          "sourceKey": "session-stop:ad00d789e1323bb74"
+        }
+      ]
+    }
+  ]
+}

--- a/.omc/state/subagent-tracking.json
+++ b/.omc/state/subagent-tracking.json
@@ -1,0 +1,17 @@
+{
+  "agents": [
+    {
+      "agent_id": "ad00d789e1323bb74",
+      "agent_type": "general-purpose",
+      "started_at": "2026-05-31T06:10:46.500Z",
+      "parent_mode": "none",
+      "status": "completed",
+      "completed_at": "2026-05-31T06:11:32.254Z",
+      "duration_ms": 45754
+    }
+  ],
+  "total_spawned": 1,
+  "total_completed": 1,
+  "total_failed": 0,
+  "last_updated": "2026-05-31T06:11:32.357Z"
+}

--- a/README.md
+++ b/README.md
@@ -4,9 +4,20 @@ A skill for Claude Code and OpenCode that removes signs of AI-generated writing 
 
 ## Installation
 
-### Claude Code
+### Claude Code (plugin marketplace — recommended)
 
-Clone directly into Claude Code's skills directory:
+Add the marketplace and install the plugin from within Claude Code:
+
+```
+/plugin marketplace add blader/humanizer
+/plugin install humanizer@humanizer
+```
+
+This installs Humanizer as a managed plugin, so you can enable, disable, and update it through `/plugin` without touching your skills directory.
+
+### Claude Code (manual clone)
+
+Or clone directly into Claude Code's skills directory:
 
 ```bash
 mkdir -p ~/.claude/skills


### PR DESCRIPTION
## What

Packages Humanizer as an installable **Claude Code plugin**, distributed through a **plugin marketplace** hosted by this same repo. Users can now manage it through `/plugin` instead of manually cloning into `~/.claude/skills`.

```
/plugin marketplace add blader/humanizer
/plugin install humanizer@humanizer
```

## Why

Today the only Claude Code install path is a manual `git clone` into the skills directory, which users have to update by hand. The plugin/marketplace flow lets Claude Code enable, disable, and update the skill for them — the same one-line install most other Claude Code skills now ship with.

## Changes

- **`.claude-plugin/plugin.json`** — plugin manifest. Uses `"skills": ["./"]` so the loader picks up the existing root `SKILL.md`. No file move required.
- **`.claude-plugin/marketplace.json`** — marketplace catalog. The repo doubles as its own single-plugin marketplace via `"source": "./"`.
- **`README.md`** — documents the marketplace install as the recommended Claude Code method, keeping the manual clone as an alternative.

## Backward compatibility

Nothing existing breaks. `SKILL.md` stays at the repo root, so:
- the legacy `git clone … ~/.claude/skills/humanizer` path still works,
- the OpenCode install path (which reads root `SKILL.md`) still works,
- the new plugin loader finds the same file via `"skills": ["./"]`.

Versions are pinned to `2.7.0` to match the skill frontmatter.

## Testing

Verified end-to-end with the `claude` CLI against this branch:

- `claude plugin validate` passes for both `plugin.json` and `marketplace.json`
- `claude plugin marketplace add` → adds successfully
- `claude plugin install humanizer@humanizer` → installs, enabled, reports version `2.7.0`
- Confirmed `SKILL.md` is discovered at the cached plugin root