### PR TITLE
feat: add formatting patterns #31-33 (tables, skipped heading levels, thematic breaks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.8.0** - Added structural/formatting patterns #31-33: tables where prose belongs, skipped heading levels, and thematic breaks before headings. 33 patterns total.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.
 - **2.5.1** - Added a passive-voice / subjectless-fragment rule, raising the total to 29 patterns

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.7.0
+version: 2.8.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -481,6 +481,49 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 
 **After:**
 > This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
+
+
+### 31. Tables Where Prose Belongs
+
+**Problem:** AI chatbots reach for a table to present information that reads better as a sentence or a short list. Watch for tables with a single data row, a column that repeats one value, or "aspect/description" pairs that are really just prose split across cells.
+
+**Before:**
+> | Feature | Description |
+> | --- | --- |
+> | Speed | The service responds quickly under normal load. |
+
+**After:**
+> Under normal load, the service responds quickly.
+
+
+### 32. Skipped Heading Levels
+
+**Problem:** AI-generated documents often jump heading levels (an `H2` followed directly by an `H4`), using heading size for visual weight rather than to express the real document hierarchy. Headings should step down one level at a time.
+
+**Before:**
+> ## Installation
+> #### Prerequisites
+
+**After:**
+> ## Installation
+> ### Prerequisites
+
+
+### 33. Thematic Breaks Before Headings
+
+**Problem:** AI chatbots scatter horizontal rules (`---`) just above section headings as decorative separators. A heading already starts a new section; the rule is redundant noise.
+
+**Before:**
+> Earlier content wraps up here.
+>
+> ---
+>
+> ## Next Section
+
+**After:**
+> Earlier content wraps up here.
+>
+> ## Next Section
 
 
 ## DETECTION GUIDANCE


### PR DESCRIPTION
Three formatting-level tells from the Wikipedia "Signs of AI writing" page that the skill doesn't cover yet. The current 30 patterns are strong on prose and word choice but light on document structure, which is where a lot of generated Markdown gives itself away.

- **#31 Tables where prose belongs** — single-row or one-value-column tables that should be a sentence.
- **#32 Skipped heading levels** — H2 jumping straight to H4, using size for weight instead of hierarchy.
- **#33 Thematic breaks before headings** — decorative `---` rules stacked on top of section headers.

Each follows the existing Problem/Before/After format. README version history updated.

Note: bumped to 2.8.0 to match the changelog convention, but #126 and #129 also target 2.8.0 — happy to renumber the patterns or the version however you'd like on merge.