### PR TITLE
Add Codex skill metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,15 @@
 # AGENTS.md
 
-Guidance for AI coding agents (Claude Code, Codex, Warp, etc.) working in this repository.
+Guidance for AI coding agents (Codex, Claude Code, OpenCode, Warp, etc.) working in this repository.
 
 ## What this repo is
 
-A **Claude Code / OpenCode skill** implemented entirely as Markdown. The runtime artifact is `SKILL.md`: the agent reads its YAML frontmatter (metadata + allowed tools) followed by the editor prompt. There is no build step and no code to run.
+A **Codex / Claude Code / OpenCode skill** implemented entirely as Markdown. The main runtime artifact is `SKILL.md`: the agent reads its YAML frontmatter followed by the editor prompt. Codex also uses `agents/openai.yaml` for UI-facing metadata. There is no build step and no code to run.
 
 ## Key files
 
-- `SKILL.md` — the skill itself. YAML frontmatter (`name`, `version`, `description`, `allowed-tools`) followed by the canonical, numbered pattern list with before/after examples. **This is the source of truth.**
+- `SKILL.md` — the skill itself. YAML frontmatter (`name`, `description`, `metadata.version`, `metadata.compatibility`, `allowed-tools`) followed by the canonical, numbered pattern list with before/after examples. **This is the source of truth.**
+- `agents/openai.yaml` — Codex UI metadata for the skill list and default prompt.
 - `README.md` — for humans: installation, usage, a summary table of the patterns, and a version history.
 
 ## The maintenance contract
@@ -16,7 +17,8 @@ A **Claude Code / OpenCode skill** implemented entirely as Markdown. The runtime
 `SKILL.md` and `README.md` must stay in sync. When you change behavior or content:
 
 - **Patterns:** the skill currently defines **30 numbered patterns**. If you add, remove, or renumber any, update the README pattern table, its "N Patterns Detected" heading, and every cross-reference in the same change. Keep numbering stable unless you are deliberately renumbering.
-- **Version:** `SKILL.md` frontmatter has a `version:` field and `README.md` has a "Version History" section. Bump both together.
+- **Version:** `SKILL.md` frontmatter metadata has a `version:` field and `README.md` has a "Version History" section. Bump both together.
+- **Codex metadata:** if you change the skill name, purpose, or default invocation, keep `agents/openai.yaml` aligned.
 - **Non-obvious fixes:** if you change the prompt to handle a tricky failure mode (a repeated mis-edit, an unexpected tone shift), add a short note to the README version history explaining what was fixed and why.
 
 ## Editing SKILL.md

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # Humanizer
 
-A skill for Claude Code and OpenCode that removes signs of AI-generated writing from text, making it sound more natural and human.
+A skill for Codex, Claude Code, and OpenCode that removes signs of AI-generated writing from text, making it sound more natural and human.
 
 ## Installation
+
+### Codex
+
+Clone directly into Codex's skills directory:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+git clone https://github.com/blader/humanizer.git "${CODEX_HOME:-$HOME/.codex}/skills/humanizer"
+```
+
+Or copy the skill files manually if you already have this repo cloned:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills/humanizer"
+cp SKILL.md "${CODEX_HOME:-$HOME/.codex}/skills/humanizer/"
+cp -R agents "${CODEX_HOME:-$HOME/.codex}/skills/humanizer/"
+```
 
 ### Claude Code
 
@@ -40,6 +57,14 @@ cp SKILL.md ~/.config/opencode/skills/humanizer/
 
 ## Usage
 
+### Codex
+
+```
+Use $humanizer to humanize this text:
+
+[paste your text here]
+```
+
 ### Claude Code
 
 ```
@@ -56,7 +81,7 @@ cp SKILL.md ~/.config/opencode/skills/humanizer/
 [paste your text here]
 ```
 
-Or ask the model to humanize text directly in either tool:
+Or ask the model to humanize text directly in any supported tool:
 
 ```
 Please humanize this text: [your text]
@@ -180,6 +205,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.8.0** - Added Codex compatibility while retaining Claude Code and OpenCode support; added `agents/openai.yaml` metadata. No change to the 30 patterns.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.
 - **2.5.1** - Added a passive-voice / subjectless-fragment rule, raising the total to 29 patterns

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: humanizer
-version: 2.7.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -9,7 +8,9 @@ description: |
   attributions, em dash overuse, rule of three, AI vocabulary words, passive
   voice, negative parallelisms, and filler phrases.
 license: MIT
-compatibility: claude-code opencode
+metadata:
+  version: 2.8.0
+  compatibility: claude-code opencode codex
 allowed-tools:
   - Read
   - Write

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Humanizer"
+  short_description: "Rewrite text to remove AI writing tells"
+  default_prompt: "Use $humanizer to rewrite pasted text so it sounds natural and human-written."


### PR DESCRIPTION
## Summary

- add Codex UI metadata in `agents/openai.yaml`
- document Codex installation and usage
- move skill version/compatibility into `metadata` and bump to 2.8.0

I used Codex to write the PR (of course :p) but it seems to work well on my machine. Let me know if additional testing can be useful!