### PR TITLE
Revise README for Humanizer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ If you want to install for specific agent, use the table below.
  
 > **Note:** OpenCode also scans `~/.claude/skills/` for compatibility, so if you use both tools, setting it up for Claude Code is enough.
 
+### Update
+
+To sync the latest changes from the repo to the local installed skill, run the command
+
+```bash
+npx skills update humanizer
+```
+
 ## Usage
 
 ### Claude Code

--- a/README.md
+++ b/README.md
@@ -1,42 +1,26 @@
 # Humanizer
 
-A skill for Claude Code and OpenCode that removes signs of AI-generated writing from text, making it sound more natural and human.
+A skill for coding agents (Claude Code, OpenCode, etc) that removes signs of AI-generated writing from text, making it sound more natural and human.
 
 ## Installation
 
-### Claude Code
-
-Clone directly into Claude Code's skills directory:
-
 ```bash
-mkdir -p ~/.claude/skills
-git clone https://github.com/blader/humanizer.git ~/.claude/skills/humanizer
+npx skills add blader/humanizer
 ```
+> This will let you install for any coding agent.
 
-Or copy the skill file manually if you already have this repo cloned:
+### Per-agent install
 
-```bash
-mkdir -p ~/.claude/skills/humanizer
-cp SKILL.md ~/.claude/skills/humanizer/
-```
+If you want to install for specific agent, use the table below.
 
-### OpenCode
-
-Clone directly into OpenCode's skills directory:
-
-```bash
-mkdir -p ~/.config/opencode/skills
-git clone https://github.com/blader/humanizer.git ~/.config/opencode/skills/humanizer
-```
-
-Or copy the skill file manually if you already have this repo cloned:
-
-```bash
-mkdir -p ~/.config/opencode/skills/humanizer
-cp SKILL.md ~/.config/opencode/skills/humanizer/
-```
-
-> **Note:** OpenCode also scans `~/.claude/skills/` for compatibility, so if you use both tools, a single clone into `~/.claude/skills/humanizer/` is enough.
+| Agent | Install command |
+|---|---|
+| **Claude Code** | `npx skills add blader/humanizer --agent claude-code` |
+| **opencode** | `npx skills add blader/humanizer --agent opencode` |
+| **Codex CLI** | `npx skills add blader/humanizer --agent codex` |
+| **Cursor** | `npx skills add blader/humanizer --agent cursor` |
+ 
+> **Note:** OpenCode also scans `~/.claude/skills/` for compatibility, so if you use both tools, setting it up for Claude Code is enough.
 
 ## Usage
 


### PR DESCRIPTION
Updated installation instructions for clarity and added per-agent install section.

- Avoids having to clone the repo
- `npx skills update` - This will sync the latest changes from this repo in one command
- `npx skills add` - This will add support for any agent out there.