### PR TITLE
Extend §13 to cover subjectless fragments from humanizing overcorrection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 10 | **Rule of three** | "innovation, inspiration, and insights" | Use natural number of items |
 | 11 | **Synonym cycling** | "protagonist... main character... central figure... hero" | "protagonist" (repeat when clearest) |
 | 12 | **False ranges** | "from the Big Bang to dark matter" | List topics directly |
-| 13 | **Passive voice / subjectless fragments** | "No configuration file needed" | Name the actor when it helps clarity |
+| 13 | **Passive voice / subjectless fragments** | "No configuration file needed", "Want to see if X?" | Name the actor; keep subjects in casual register too |
 
 ### Style Patterns
 
@@ -183,6 +183,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.8.1** - Extended §13 to cover subjectless fragments produced as a humanizing overcorrection ("Want to see if X?", "Hit reply to opt out") in addition to the existing technical/UI-voice case ("No configuration file needed"); added a distinguished-from-§31 note. 33 patterns total.
 - **2.8.0** - Added style/cadence patterns #31-33 for manufactured punchlines, aphorism formulas, and conversational rhetorical openers; expanded #20 to catch offer-to-continue chatbot closers. 33 patterns total.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.8.0
+version: 2.8.1
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -245,13 +245,26 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 ### 13. Passive Voice and Subjectless Fragments
 
-**Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
+**Problem:** LLMs hide the actor or drop the subject in two distinct registers:
 
-**Before:**
+1. *Technical / UI voice:* lines like "No configuration file needed" or "The results are preserved automatically." The actor is hidden behind passive voice or elided entirely.
+2. *Humanizing overcorrection:* when asked to make text sound casual or natural, the editor often reaches for subjectless fragments ("Want to see if X?", "Hit reply to opt out", "Ninety days since X.") on the theory that brevity reads as natural speech. The opposite is true. Real casual speech keeps subjects and verbs; it uses contractions, shorter clauses, and informal vocabulary, not missing grammar. Telegraphic copy reads as rushed, not human.
+
+Rewrite both by naming the actor and using complete clauses.
+
+**Before (technical / UI):**
 > No configuration file needed. The results are preserved automatically.
 
 **After:**
 > You do not need a configuration file. The system preserves the results automatically.
+
+**Before (humanizing overcorrection):**
+> Want to see if your views have shifted? Hit reply to opt out.
+
+**After:**
+> Would you like to see whether your views have shifted? You can reply to this email if you would like to opt out.
+
+**Distinguished from §31:** §31 catches *runs* of fragments stacked to manufacture drama ("It had no preference. No prior. No nostalgia."). This pattern catches *isolated* fragments produced as a shortcut to "sounding casual," where the failure is not over-dramatic but underspecified.
 
 
 ## STYLE PATTERNS


### PR DESCRIPTION
Closes #146.

Extends §13 to cover subjectless fragments produced as a humanizing overcorrection, alongside the existing technical-voice case.

## Why

I saw this happen in real use. I was applying the skill to a set of transactional email templates and produced lines like:

- "Want to see if your views have shifted?"
- "Hit reply to opt out."
- "Ninety days since X took the quiz."

All three drop the subject as a shortcut to "sounding casual." The user (a real human) called it staccato and asked for complete grammatical sentences like "Would you like to see how your stance moved?" instead.

§13 already covers the missing-subject tell but only in the technical/UI register ("No configuration file needed"). §31 covers fragments-for-drama but not fragments-for-casual. Neither catches this specific failure: an isolated fragment produced because the editor thought brevity equals naturalness.

## What

- `SKILL.md` §13: rewrite the **Problem** paragraph to name two registers (technical/UI and humanizing-overcorrection), add a second Before/After pair, and add a Distinguished-from-§31 note.
- `README.md`: update the §13 table row with the second example and a tighter After-column summary; add a 2.8.1 line to Version History.
- `SKILL.md` frontmatter: bump version `2.8.0` -> `2.8.1`.

Pattern count stays at 33.

## Out of scope

I considered adding this as a new §34 pattern. Decided against it because the underlying tell (missing subject) is identical to §13; the only difference is the register the editor was aiming for. Extending §13 keeps the count stable and surfaces both registers under the same head. Happy to split if you'd rather have a separate §34, though.
