### PR TITLE
Add Spanish pattern catalog with automatic language detection (v2.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Now humanize this text:
 
 The skill will analyze your sentence rhythm, word choices, and quirks, then apply them to the rewrite instead of producing generic "clean" output.
 
+### Spanish / Español
+
+The skill detects the input language automatically. For Spanish text it loads [`references/patrones-espanol.md`](references/patrones-espanol.md), a parallel catalog of Spanish-specific AI tells: filler connectors ("Cabe destacar", "En definitiva"), calque openers ("En el mundo actual…"), brochure verbs ("potenciar", "fomentar"), superfluous gerund chains, and a full before/after example in Spanish. The structural rules (rule of three, uniform sentence length, em-dash discipline) carry over from the English catalog; only the word lists and examples change. Rewrites always stay in the language of the input — nothing gets translated.
+
+```
+/humanizer
+
+Humaniza este texto: [tu texto en español]
+```
+
 ## Overview
 
 Based on [Wikipedia's "Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) guide, maintained by WikiProject AI Cleanup. This comprehensive guide comes from observations of thousands of instances of AI-generated text.
@@ -183,6 +193,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.9.0** - Added Spanish language support: automatic language detection routes Spanish input to `references/patrones-espanol.md`, a parallel catalog of Spanish AI tells (filler connectors, calque openers, brochure verbs, superfluous gerunds) with a Spanish before/after example. English catalog and the 33 patterns unchanged.
 - **2.8.0** - Added style/cadence patterns #31-33 for manufactured punchlines, aphorism formulas, and conversational rhetorical openers; expanded #20 to catch offer-to-continue chatbot closers. 33 patterns total.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: humanizer
-version: 2.8.0
+version: 2.9.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
   comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
   inflated symbolism, promotional language, superficial -ing analyses, vague
   attributions, em dash overuse, rule of three, AI vocabulary words, passive
-  voice, negative parallelisms, and filler phrases.
+  voice, negative parallelisms, and filler phrases. Bilingual: detects whether
+  the input is English or Spanish and applies the matching pattern catalog
+  (Spanish patterns live in references/patrones-espanol.md). Use also when asked
+  in Spanish to redactar, humanizar, or reescribir un texto so it doesn't read
+  as AI-generated.
 license: MIT
 compatibility: claude-code opencode
 allowed-tools:
@@ -34,6 +38,20 @@ When given text to humanize:
 
 The draft → audit → final loop and the deliverable are defined under Process and Output, below.
 
+
+## Language / Idioma (detect first)
+
+Before anything else, detect the language of the input:
+
+- **English** → use the pattern catalog in this file as-is.
+- **Spanish / español** → ALSO load `references/patrones-espanol.md` and apply the
+  Spanish vocabulary, connectors, calque openers and examples from there. The
+  structural and stylistic principles in this file (rule of three, uniform
+  sentence length, em-dash discipline, copula avoidance, hedging, sycophancy,
+  filler) still apply — only the word lists and examples change.
+- **Mixed / other** → humanize each passage in its own language; never translate.
+
+Always deliver the rewrite in the same language as the input.
 
 ## Voice Calibration (Optional)
 

--- a/references/patrones-espanol.md
+++ b/references/patrones-espanol.md
@@ -1,0 +1,148 @@
+# Patrones de escritura IA en ESPAÑOL (Spanish AI writing patterns)
+
+Complemento en español del catálogo inglés de `SKILL.md`. Los **principios
+estructurales** (inflación de significancia, regla de tres, exceso de raya,
+evitación de "ser/estar", hedging, adulación, relleno) son los mismos: aquí solo
+cambian el **vocabulario** y los **ejemplos**, porque los delatores del español
+no coinciden con los del inglés. Para cada grupo, el porqué está en `SKILL.md`;
+aquí tienes el equivalente castellano que sí dispara en texto en español.
+
+> Regla: el texto se humaniza en el idioma en que está escrito. No traduzcas;
+> reescribe en español natural. Conserva tildes, "tú/usted", y registro.
+
+---
+
+## A. Vocabulario IA sobreusado (lista de prohibidos)
+
+Sustituye por la palabra concreta o reestructura la frase. Nunca uses de oficio:
+
+**Conectores-muletilla:** Además, · Asimismo, · Por otro lado, · En este sentido, ·
+Cabe destacar/señalar/mencionar · Es importante destacar/recordar/señalar ·
+Dicho esto, · No obstante, · En definitiva, · En resumen, · En conclusión, ·
+Por último, pero no menos importante, (calco de *last but not least*).
+
+**Inflado de importancia:** se erige como · constituye un testimonio de · marca un
+hito · juega/desempeña un papel crucial/fundamental · en un mundo cada vez más ·
+pilar fundamental · piedra angular · rico tapiz/abanico de · de vital importancia.
+
+**Adjetivos-comodín:** crucial · fundamental · esencial · clave · robusto · integral ·
+holístico · innovador · revolucionario · vanguardista · sin precedentes · invaluable.
+
+**Verbos de folleto:** potenciar · impulsar · fomentar · garantizar · abordar ·
+optimizar · desbloquear (el potencial) · revolucionar · empoderar · navegar (por
+los retos de).
+
+**Aperturas-calco (eliminar siempre):** "En el mundo actual…" · "En la era digital…" ·
+"En el acelerado mundo de hoy…" · "En el vasto mundo de…" · "A lo largo de la
+historia…" · "Desde tiempos inmemoriales…".
+
+## B. Estructura (los mismos vicios que en inglés, en español)
+
+- **Regla de tres / triadas:** "rápido, fácil y eficaz", "reduce, mejora y previene".
+  Rómpela: usa dos, cuatro o una. Solo tres si de verdad hay tres cosas.
+- **Paralelismo negativo (calco):** "No se trata solo de X, sino de Y", "No es X, es Y",
+  "no solo… sino también…". Patrón rítmico delator: reescribe en afirmativo.
+- **Gerundio superfluo** (equivalente al "-ing" inglés): frases que acaban en
+  "…, permitiendo…", "…, logrando…", "…, garantizando…", "…, lo que se traduce en…".
+  Corta y haz frase aparte.
+- **Pasiva refleja / "ser" sobreusado:** "se considera que", "es ampliamente
+  reconocido", "fue diseñado para". Pasa a activa y directa.
+- **Longitud uniforme:** nunca tres frases seguidas de igual longitud. Mezcla una
+  de 4 palabras con una de 30. Es la señal más medible.
+- **Sectorización excesiva:** muchos H3, listas para todo. Disuelve en prosa cuando
+  quepa en una frase.
+
+## C. Puntuación y formato
+
+- **Raya (—):** el español la usa para incisos y diálogo; la IA la mete como pausa
+  dramática igual que en inglés. Máximo una por cada 500 palabras; prefiere coma,
+  punto y coma, dos puntos o frase nueva.
+- **Negritas aleatorias** para "enfatizar" media frase: fuera.
+- **Comillas tipográficas curvas y emojis como viñetas** (✅🔥💡 al inicio de cada
+  línea): delator instantáneo.
+- **Título con Mayúsculas En Cada Palabra:** en español los títulos van en
+  mayúscula solo la primera palabra (y nombres propios). Title-case = calco IA.
+
+## D. Comunicación y tono
+
+- **Adulación/servilismo:** "¡Gran pregunta!", "¡Claro que sí!", "Espero que esto
+  te sirva/ayude", "¡No dudes en preguntar!", "Estaré encantado de ayudarte". Borrar.
+- **Aperturas retóricas:** "¿Alguna vez te has preguntado…?", "Imagina por un
+  momento…". Entra directo al tema.
+- **Avisos de corte de conocimiento:** "Según la información disponible…",
+  "Hasta donde alcanza mi conocimiento…". Eliminar.
+
+## E. Relleno, hedging y cierres
+
+- **Relleno:** "es importante tener en cuenta que", "vale la pena mencionar que",
+  "como es bien sabido", "en términos generales".
+- **Hedging en sube y baja:** "podría decirse que… aunque también… si bien… no
+  obstante…". Moja: postura clara y un contrapunto como mucho.
+- **Cierre genérico:** "En definitiva, el futuro es prometedor", "Solo el tiempo lo
+  dirá", "Sin duda, marcará un antes y un después". Termina con algo concreto o
+  simplemente termina.
+
+---
+
+## Qué SÍ hacer (en español)
+
+- **Sé concreto:** "te dice que en 47 días te quedas sin stock" > "potentes
+  capacidades de análisis".
+- **Usa cifras reales:** "34 personas la primera semana; 12 volvieron al día
+  siguiente" > "un crecimiento significativo".
+- **Nombra cosas reales:** "en Valencia", "el INE", "un estudio de 2026" > "diversos
+  estudios", "una entidad de referencia".
+- **Contracciones y coloquialismos naturales del registro:** "pa'", "vamos", "oye"
+  solo si la voz del autor lo pide; no los fuerces (ver trampas más abajo).
+- **Deja que alguna frase quede fea:** fragmento. O una larga que se alarga porque
+  la idea aún no ha terminado. Eso es humano.
+- **Nunca inventes datos, estudios, citas ni anécdotas.** Si no tienes el dato:
+  "alrededor de", "más o menos", o reconoce que no lo sabes.
+
+## Trampas (parecen humanizar pero delatan)
+
+Validadas empíricamente contra GPTZero en artículos SEO en español (10
+iteraciones sobre contenido real). No las apliques aunque "suenen" humanas:
+
+- Frases cortas tipo "Real.", "Paras.", "Vete." → *Artificial Simplicity*.
+- Helper-language ("échale un ojo", "vamos al lío") → *Helper Language* (estilo
+  chatbot).
+- Detalles sensoriales improbables inventados en primera persona → *Generic
+  First-Person*.
+- URLs en línea dentro del texto → *Engagement Features* (van en HTML al publicar,
+  no en el texto que se escanea).
+- Antítesis "no en X, sino en Y" → *Mechanical Transitions*.
+
+---
+
+## Ejemplo completo (español)
+
+**Antes (suena a IA):**
+> ¡Gran pregunta! En el mundo actual, el yoga prenatal se erige como una práctica
+> fundamental que desempeña un papel crucial en el bienestar de la embarazada.
+> Cabe destacar que no solo mejora la flexibilidad, sino que también reduce el
+> estrés, fomenta la conexión con el bebé y potencia la calidad del sueño. Además,
+> diversos estudios respaldan sus innumerables beneficios. En definitiva, sin lugar
+> a dudas, el futuro de la maternidad consciente es prometedor. ¡Espero que esto te
+> ayude!
+
+**Borrador reescrito:**
+> El yoga prenatal ayuda con tres cosas que veo en consulta a diario: dormir mejor,
+> respirar con más control en los últimos meses y llegar al parto con menos miedo.
+> No es magia ni cura nada. A algunas mujeres les encaja y a otras les aburre, y
+> las dos reacciones me parecen razonables.
+
+**¿Qué lo delata todavía?**
+- "tres cosas" sigue siendo una triada; mejor desigual.
+- El cierre suena un pelín a eslogan.
+
+**Versión final (que no parezca IA):**
+> El yoga prenatal me sirve sobre todo para una cosa: que la mujer llegue al parto
+> respirando con cierto control y sin tanto miedo. De propina suele dormir mejor.
+> No cura nada, que conste. Y oye, a unas les encaja y a otras les aburre
+> soberanamente; las dos reacciones me parecen igual de válidas.
+
+**Cambios:** fuera la apertura "En el mundo actual", el inflado "se erige/papel
+crucial", la triada con paralelismo negativo, el "Además + diversos estudios", el
+cierre genérico y la adulación; reconstruida con voz en primera persona, detalle
+concreto y ritmo desigual.


### PR DESCRIPTION
## What

Adds Spanish language support, requested in #138:

- **`references/patrones-espanol.md`** — a parallel catalog of Spanish-specific AI tells, mirroring the English catalog's structure: filler connectors ("Cabe destacar", "En definitiva", "Asimismo"), calque openers ("En el mundo actual…", "En la era digital…"), importance inflation ("se erige como", "papel crucial"), brochure verbs ("potenciar", "fomentar", "empoderar"), superfluous gerund chains ("…, permitiendo…", "…, garantizando…"), Spanish-flavored sycophancy and generic closers, plus a complete before/draft/audit/final example in Spanish following the skill's existing loop.
- **`SKILL.md`** — a short "Language / Idioma (detect first)" section that routes Spanish input to the Spanish catalog and keeps the English catalog as the default. Structural principles (rule of three, uniform sentence length, em-dash discipline, copula avoidance, hedging, filler) are explicitly shared — only word lists and examples change. Rewrites always stay in the input language.
- **`README.md`** — "Spanish / Español" usage subsection + version history entry, per the AGENTS.md maintenance contract (version bumped to 2.9.0 in both files; the 33 numbered patterns are untouched and not renumbered).

## Why

The English tells (delve, tapestry, "serves as", -ing chains) mostly don't fire on Spanish text, so Spanish users currently get near-zero pattern coverage (#138, and earlier #92). Spanish AI slop has its own statistically detectable fingerprint — the connector/opener/verb lists here come from iterating on real Spanish SEO articles against GPTZero (10 documented iterations), not from translating the English list.

The catalog file is written in Spanish deliberately: it's loaded only when the input is Spanish, and showing the patterns in-language avoids the lossy translation problem that motivated the file in the first place.

## Notes

- Additive and backward-compatible: English-only users see no behavior change.
- The same reference-file structure could host future languages (pt, fr, de) without touching the English catalog.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)