### PR TITLE
Add secondhand-text exemption to Detection Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.8.1** - Added a secondhand-text exemption to Detection Guidance: never rewrite a watched phrase that appears in a quotation, a title or proper name, a use-mention, or a historical source. No change to the 33 patterns.
 - **2.8.0** - Added style/cadence patterns #31-33 for manufactured punchlines, aphorism formulas, and conversational rhetorical openers; expanded #20 to catch offer-to-continue chatbot closers. 33 patterns total.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.8.0
+version: 2.8.1
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -538,6 +538,8 @@ A clean human writer can hit several of the patterns above without any AI involv
 - **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
 - **Unsourced claims.** Most of the web is unsourced. Lack of citations doesn't prove anything.
 - **Correct, complex formatting.** Visual editors and templates produce clean output without any AI.
+
+- **Secondhand text.** Never rewrite a watched phrase the author did not author. Leave it inside quotation marks or attributed reported speech (she called the rollout "painfully slow"), in a proper noun, title, brand, or product name (the film *Blazing Saddles*, a product called "Dead Simple"), in a use-mention where the phrase is discussed rather than used ("avoid 'blazingly fast', it's a cliche"), or in a historical source. The author's own use of the same phrase is judged normally. This applies to every pattern, not only the intensifier rules.
 
 When in doubt, look for **clusters** of tells, not isolated ones. A single em dash means nothing; em dashes plus rule-of-three plus *vibrant tapestry* plus a "Conclusion" section is a confession.
 


### PR DESCRIPTION
The skill currently has no guidance for watched phrases the writer did not author, so a quoted phrase, a work title, or a use-mention is fair game for rewriting. That means the humanizer can change words inside someone else's quote or a product name.

This adds one bullet to the "What NOT to flag" section of Detection Guidance that leaves those alone: quotation and reported speech, proper nouns and titles, use-mention, and historical sources. The author's own use of the same phrase is still judged normally.

It applies to every pattern, not just one, and it does not add or renumber any pattern. Version bumped to 2.8.1 with a history note.
