### PR TITLE
Add pattern #34: casual intensifiers and dismissive amplifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
-## 33 Patterns Detected (with Before/After Examples)
+## 34 Patterns Detected (with Before/After Examples)
 
 ### Content Patterns
 
@@ -131,6 +131,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 31 | **Manufactured punchlines / staccato drama** | "It had no preference. No prior. No nostalgia." | Use varied sentence lengths and concrete claims |
 | 32 | **Aphorism formulas** | "Symmetry is the language of trust" | Replace the formula with the actual claim |
 | 33 | **Conversational rhetorical openers** | "Honestly? It depends..." | Remove the fake-candid setup |
+| 34 | **Casual intensifiers / dismissive amplifiers** | "blazingly fast", "just a glorified wrapper" | Flag in neutral register, keep idioms and terms of art |
 
 ### Communication Patterns
 
@@ -183,6 +184,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.9.0** - Added pattern #34 (casual intensifiers and dismissive amplifiers): flags hype like "blazingly fast" and belittling templates like "a glorified X" when they outrun a neutral register, with carve-outs for idioms, terms of art, manner adverbs, and substantiated claims. 34 patterns total.
 - **2.8.0** - Added style/cadence patterns #31-33 for manufactured punchlines, aphorism formulas, and conversational rhetorical openers; expanded #20 to catch offer-to-continue chatbot closers. 33 patterns total.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.8.0
+version: 2.9.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -518,6 +518,22 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 
 **After:**
 > Whether it's worth the price depends on how often you'll use it.
+
+
+### 34. Casual Intensifiers and Dismissive Amplifiers
+
+**Words to watch:** dead simple, blazingly fast, dirt cheap, wildly, insanely, ridiculously, stupidly, painfully slow, hopelessly outdated, woefully thin, jaw-droppingly, eye-wateringly, X as hell, X af. Dismissive templates: just a dumb X, a glorified X, a mere X, nothing but a X.
+
+**Problem:** LLMs reach for blog-register punch and drop casual intensifiers and belittling amplifiers into prose meant to be neutral. The lift outruns the register, and the dismissive asserts a verdict the text has not earned.
+
+The bar scales with register. In neutral, reference, or formal prose, one intensifier already breaks it. Casual and creative-work writing tolerate a couple and flag only on density. A dismissive gets no register discount: one unsupported "a glorified X" keys anywhere, unless the same passage names the concrete shortfall that earns it.
+
+Flag only the degree modifier sitting right before an adjective ("insanely fast", "dead simple"). Leave the manner adverb ("prices swung wildly"), the term of art ("dead letter queue"), the fossilized idiom ("painfully shy", "dead wrong"), and any amplifier a figure substantiates on the same dimension ("insanely hot, 260C").
+
+**Before:** The library is blazingly fast and the API is dead simple, basically just a glorified wrapper.
+**After:** The library is fast, and the API exposes three methods over a thin wrapper around fetch.
+
+Openers belong to section 33, cadence to section 31, lyrical praise to section 4.
 
 
 ## DETECTION GUIDANCE


### PR DESCRIPTION
Proposed in #153.

One tell the current patterns miss: casual intensifiers (dead simple, blazingly fast, painfully slow) and belittling templates (just a dumb X, a glorified X) that manufacture confidence in prose meant to be neutral. #7 covers flavor vocabulary, #31 cadence, #4 promotional adjectives, none of them this class.

The rule scales by register: one intensifier already breaks neutral or reference prose, while casual and creative-work writing tolerate a couple. It carves out idioms, terms of art, manner adverbs, and substantiated claims, so "dead letter queue" and "painfully shy" stay. Kept terse to match the house patterns.

Updates the README pattern table and count, and bumps the version to 2.9.0.
