### PR TITLE
Add pattern #34: hallucinated data, fake citations, and fabricated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
-## 33 Patterns Detected (with Before/After Examples)
+## 34 Patterns Detected (with Before/After Examples)
 
 ### Content Patterns
 
@@ -148,6 +148,12 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 24 | **Excessive hedging** | "could potentially possibly" | "may" |
 | 25 | **Generic conclusions** | "The future looks bright" | Specific plans or facts |
 
+### Factuality and Sourcing
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 34 | **Hallucinated data / fake citations / fabricated links** | "studies show 73%... (https://jse.org/...)" | Verify and cite, or flag `[unverified - needs source]` — never invent a source |
+
 ## Full Example
 
 **Before (AI-sounding):**
@@ -183,6 +189,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.9.0** - Added pattern #34 (hallucinated data, fake citations, fabricated links) in a new "Factuality and Sourcing" section, plus a fact-check pass as the first step of the process and a sourcing report in the deliverable. The rule is verify-and-cite or flag, and never invent a source, since a fabricated statistic or dead link survives a style edit and reads more credible after polishing. 34 patterns total.
 - **2.8.0** - Added style/cadence patterns #31-33 for manufactured punchlines, aphorism formulas, and conversational rhetorical openers; expanded #20 to catch offer-to-continue chatbot closers. 33 patterns total.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: humanizer
-version: 2.8.0
+version: 2.9.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
   comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
   inflated symbolism, promotional language, superficial -ing analyses, vague
   attributions, em dash overuse, rule of three, AI vocabulary words, passive
-  voice, negative parallelisms, and filler phrases.
+  voice, negative parallelisms, filler phrases, and hallucinated data, fake
+  citations, or fabricated links.
 license: MIT
 compatibility: claude-code opencode
 allowed-tools:
@@ -520,6 +521,28 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 > Whether it's worth the price depends on how often you'll use it.
 
 
+## FACTUALITY AND SOURCING
+
+### 34. Hallucinated Data, Fake Citations, and Fabricated Links
+
+**Signs to watch:** suspiciously clean statistics with no source ("studies show 73% of..."), named studies, reports, or surveys that may not exist, quotes attributed to real people without a traceable origin, plausible-looking URLs nobody checked, DOIs / ISBNs / case numbers / dates / dollar figures stated with confidence but no provenance.
+
+**Problem:** This is the most damaging tell because it survives a style edit untouched. The prose reads clean while the facts are invented. LLMs fill gaps with plausible numbers, citations, and links instead of admitting they don't know, and a polishing pass makes the fabrication *more* convincing, not less. A rewrite that leaves a fake statistic or a dead link in place has made the text worse, because it now reads credibly.
+
+**Rules:**
+
+1. **Don't assume.** Treat every specific data point, statistic, quote, named source, date, and URL as unverified until checked. Plausibility is not verification. A number that "sounds about right" is exactly the trap.
+2. **Verify when you can.** If web or other research access is available, confirm each factual claim and every link against a primary or reputable source. Check that cited URLs actually resolve and actually say what the text claims, and that named studies, papers, and people exist.
+3. **Cite what you keep.** Every retained data point or quote should carry a citation to a real, working source. Prefer primary sources and link directly to them.
+4. **When you cannot verify:** never paraphrase a guess into fact. Either (a) cut the claim, (b) soften it to what is genuinely known and say plainly what is not, or (c) mark it `[unverified - needs source]` so it cannot ship by accident. **Never invent a citation or URL.** A fabricated source is worse than an admitted gap.
+
+**Before:**
+> A recent study found that 73% of developers report higher productivity with AI coding tools, according to research published in the Journal of Software Engineering (https://jse.org/ai-productivity-2024).
+
+**After (verifiable claim kept and cited; the rest flagged, not faked):**
+> In GitHub's 2024 developer survey, most respondents said AI tools improved their productivity (GitHub, "Survey: The AI wave continues to grow," 2024; confirm the exact live URL before publishing). [The specific "73%" figure and the "Journal of Software Engineering" citation could not be verified and were removed; restore only with a real source. The original URL did not resolve.]
+
+
 ## DETECTION GUIDANCE
 
 ### What NOT to flag (false positives)
@@ -560,11 +583,12 @@ When you see these, lean toward leaving the prose alone — they are evidence of
 ## Process and Output
 
 1. Read the input carefully and identify every instance of the patterns above.
-2. Write a **draft rewrite**. Check that it reads naturally aloud, varies sentence length, prefers specific details and simple constructions (is/are/has), and keeps the appropriate register.
-3. Ask: **"What makes the below so obviously AI generated?"** Answer briefly with any remaining tells.
-4. Revise into a **final rewrite** that addresses them and contains no em or en dashes (see §14).
+2. **Fact-check pass (see §34).** Before rewriting, list every specific data point, statistic, quote, named source, date, and URL. Assume none are correct. Verify what you can and note a citation for each; flag or cut what you can't. Do this first so you never polish a false claim into something more convincing.
+3. Write a **draft rewrite**. Check that it reads naturally aloud, varies sentence length, prefers specific details and simple constructions (is/are/has), and keeps the appropriate register. Keep every verified fact attached to its citation.
+4. Ask: **"What makes the below so obviously AI generated?"** Answer briefly with any remaining tells.
+5. Revise into a **final rewrite** that addresses them, contains no em or en dashes (see §14), carries a citation for every retained data point and quote, and leaves no unverified claim asserted as fact.
 
-Deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optionally) a short summary of changes.
+Deliver the draft, the brief "still-AI" bullets, a short **sourcing report** (verified / cited, softened, removed, or `[unverified - needs source]`), the final rewrite, and (optionally) a short summary of changes.
 
 
 ## Full Example


### PR DESCRIPTION
## What this adds

A new **Factuality and Sourcing** section with **pattern #34 — Hallucinated Data, Fake Citations, and Fabricated Links**, plus:

- a **fact-check pass** as step 1 of the *Process and Output* loop (before the rewrite), and
- a **sourcing report** in the deliverable.

## Why

Fabricated data is itself a sign of AI writing, but unlike the other 33 patterns it is invisible to a style edit: a made-up statistic, a citation to a study that does not exist, or a plausible-but-dead URL passes straight through the humanizer untouched, and polishing the surrounding prose makes it read *more* credible, not less. As it stands, the skill can make a hallucination look more trustworthy.

Pattern #34 closes that gap with four rules: **don't assume**, **verify when you can**, **cite what you keep**, and when you cannot verify, **flag `[unverified - needs source]` or cut it, never invent a source.**

## Scope / design notes

- **No new tools required.** Verification is worded as "if web or other research access is available," so the pattern degrades gracefully in tool-light runtimes; the core behavior (flag, do not fabricate) needs no tools. I left `allowed-tools` unchanged, happy to add `WebSearch`/`WebFetch` if you would prefer verification be first-class.
- **Maintenance contract (`AGENTS.md`) followed:** `SKILL.md` bumped to `2.9.0`, README pattern count `33` to `34`, new README table row, Version History entry, pattern numbering left stable.
- Output examples stay em-dash-free per §14 (the flag marker uses a hyphen).

Same Wikipedia "Signs of AI writing" lineage as the rest of the skill, since fabricated references are a documented AI-cleanup signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
