### PR TITLE
Add Claude Code plugin and marketplace manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace-manifest.json",
+  "name": "humanizer",
+  "owner": {
+    "name": "blader",
+    "url": "https://github.com/blader"
+  },
+  "description": "The humanizer skill, installable as a Claude Code plugin.",
+  "plugins": [
+    {
+      "name": "humanizer",
+      "source": "./",
+      "description": "Remove signs of AI-generated writing from text, making it sound more natural and human. Based on Wikipedia's \"Signs of AI writing\" guide.",
+      "license": "MIT",
+      "keywords": ["writing", "editing", "ai-detection", "humanize", "prose", "style"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "humanizer",
+  "description": "Remove signs of AI-generated writing from text, making it sound more natural and human. Based on Wikipedia's \"Signs of AI writing\" guide.",
+  "version": "2.9.0",
+  "author": {
+    "name": "blader",
+    "url": "https://github.com/blader"
+  },
+  "homepage": "https://github.com/blader/humanizer",
+  "repository": "https://github.com/blader/humanizer",
+  "license": "MIT",
+  "keywords": ["writing", "editing", "ai-detection", "humanize", "prose", "style"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,15 @@ A **Claude Code / OpenCode skill** implemented entirely as Markdown. The runtime
 
 - `SKILL.md` — the skill itself. YAML frontmatter (`name`, `version`, `description`, `allowed-tools`) followed by the canonical, numbered pattern list with before/after examples. **This is the source of truth.**
 - `README.md` — for humans: installation, usage, a summary table of the patterns, and a version history.
+- `.claude-plugin/plugin.json` — plugin manifest (name, version, metadata). Lets the repo install as a Claude Code plugin.
+- `.claude-plugin/marketplace.json` — single-repo marketplace entry so `/plugin marketplace add blader/humanizer` works.
 
 ## The maintenance contract
 
 `SKILL.md` and `README.md` must stay in sync. When you change behavior or content:
 
 - **Patterns:** the skill currently defines **33 numbered patterns**. If you add, remove, or renumber any, update the README pattern table, its "N Patterns Detected" heading, and every cross-reference in the same change. Keep numbering stable unless you are deliberately renumbering.
-- **Version:** `SKILL.md` frontmatter has a `version:` field and `README.md` has a "Version History" section. Bump both together.
+- **Version:** `SKILL.md` frontmatter has a `version:` field, `README.md` has a "Version History" section, and `.claude-plugin/plugin.json` has a `version` field. Bump all three together so the plugin version matches the skill. (`marketplace.json` intentionally omits a version so `plugin.json` stays the single source of truth.)
 - **Non-obvious fixes:** if you change the prompt to handle a tricky failure mode (a repeated mis-edit, an unexpected tone shift), add a short note to the README version history explaining what was fixed and why.
 
 ## Editing SKILL.md

--- a/README.md
+++ b/README.md
@@ -4,7 +4,18 @@ A skill for Claude Code and OpenCode that removes signs of AI-generated writing 
 
 ## Installation
 
-### Claude Code
+### Plugin (recommended)
+
+Install as a Claude Code plugin so it stays updated with `/plugin update`:
+
+```
+/plugin marketplace add blader/humanizer
+/plugin install humanizer@humanizer
+```
+
+The skill is then invoked as `/humanizer:humanizer` (Claude Code namespaces plugin skills under the plugin name).
+
+### Claude Code (manual)
 
 Clone directly into Claude Code's skills directory:
 
@@ -183,6 +194,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.9.0** - Packaged as an installable Claude Code plugin and single-repo marketplace (`.claude-plugin/plugin.json` + `marketplace.json`). No change to the 33 patterns.
 - **2.8.0** - Added style/cadence patterns #31-33 for manufactured punchlines, aphorism formulas, and conversational rhetorical openers; expanded #20 to catch offer-to-continue chatbot closers. 33 patterns total.
 - **2.7.0** - Added pattern #30 (diff-anchored writing); made em/en dashes a hard cut rather than "overuse"; expanded #21 to cover speculative gap-filling ("maintains a low profile"). 30 patterns total.
 - **2.6.0** - Cleanup pass: consolidated the duplicated workflow sections, gated the personality guidance to content where voice is wanted, removed the model-fingerprinting subsection, and condensed the worked example. No change to the 29 patterns.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.8.0
+version: 2.9.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's


### PR DESCRIPTION
Packages the skill as an installable Claude Code plugin and a single-repo marketplace. You can install it with `/plugin` and update it with `/plugin update` instead of cloning by hand.

`SKILL.md` stays at the repo root, so the existing clone-based install methods in the README still work. I checked that Claude Code discovers a root-level `SKILL.md` as a plugin skill, so it didn't need to move into a `skills/` directory.

What's in the PR:
- `.claude-plugin/plugin.json`: the plugin manifest
- `.claude-plugin/marketplace.json`: a marketplace entry with source `./`, so the repo is both the marketplace and the plugin it ships
- `README.md`: a new "Plugin (recommended)" install section
- `AGENTS.md`: adds the two manifests to Key files and extends the version contract to cover `plugin.json`
- Version bumped to 2.9.0 in the `SKILL.md` frontmatter, the README history, and `plugin.json`. The 33 patterns are unchanged. This is packaging only.

Install:
```
/plugin marketplace add blader/humanizer
/plugin install humanizer@humanizer
```
Then invoke it as `/humanizer:humanizer`.

How I verified it:
- `claude plugin validate . --strict` passes for both manifests
- a local install reports `Skills (1) humanizer` in the component inventory, then uninstalls cleanly
