### PR TITLE
feat: add Universal Audience Appeals detection pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
-## 24 Patterns Detected (with Before/After Examples)
+## 34 Patterns Detected (with Before/After Examples)
 
 ### Content Patterns
 
@@ -58,6 +58,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 4 | **Promotional language** | "nestled within the breathtaking region" | "is a town in the Gonder region" |
 | 5 | **Vague attributions** | "Experts believe it plays a crucial role" | "according to a 2019 survey by..." |
 | 6 | **Formulaic challenges** | "Despite challenges... continues to thrive" | Specific facts about actual challenges |
+| 34 | **Universal audience appeals** | "Whether you are a seasoned engineer or a complete beginner..." | "This tool handles both complex and basic workflows." |
 
 ### Language Patterns
 
@@ -132,6 +133,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.9.0** - Added pattern #34 for universal audience appeals
 - **2.2.0** - Added a final "obviously AI generated" audit + second-pass rewrite prompts
 - **2.1.1** - Fixed pattern #18 example (curly quotes vs straight quotes)
 - **2.1.0** - Added before/after examples for all 24 patterns

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: humanizer
-version: 2.2.0
+version: 2.9.0
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
@@ -151,6 +151,22 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 **After:**
 > Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+
+---
+
+### 34. Universal Audience Appeals
+
+**Words to watch:** Whether you are/you're a seasoned expert or a complete beginner, for everyone from beginners to experts, beginners and experts alike, no matter your skill level, whether advanced or just getting started
+
+**Problem:** LLMs try to maximize apparent usefulness by explicitly promising value to every reader skill level at once.
+
+**Before:**
+> Whether you are a seasoned engineer or a complete beginner, this tool has something to offer.
+
+**After:**
+> This tool handles both complex and basic workflows.
+
+**Note:** The universal-audience framing reads like AI marketing fluff because it flatters every possible reader instead of naming the actual capability. Preserve specific audience assumptions ("This guide assumes you already know Git") and factual feature ranges ("The API supports both REST and GraphQL").
 
 ---
 


### PR DESCRIPTION
## Summary
Adds a "Universal Audience Appeals" detection pattern to the humanizer skill: text that flatters every reader at once ("whether you're a beginner or an expert...") reads as AI-generated filler. The new pattern detects and rewrites these catch-all appeals. Updates the README pattern table, heading count, and changelog per the repo's documented pattern-addition contract.

Fixes #137
