### PR TITLE
Add catalog-colon writing pattern

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "humanizer",
   "description": "Remove signs of AI-generated writing from text, making it sound more natural and human. Based on Wikipedia's \"Signs of AI writing\" guide.",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "author": {
     "name": "blader",
     "url": "https://github.com/blader"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ A portable agent skill implemented entirely as Markdown. The runtime artifact is
 
 `SKILL.md` and `README.md` must stay in sync. When you change behavior or content:
 
-- **Patterns:** the skill currently defines **33 numbered patterns**. If you add, remove, or renumber any, update the README pattern table, its "N Patterns Detected" heading, and every cross-reference in the same change. Keep numbering stable unless you are deliberately renumbering.
+- **Patterns:** the skill currently defines **34 numbered patterns**. If you add, remove, or renumber any, update the README pattern table, its "N Patterns Detected" heading, and every cross-reference in the same change. Keep numbering stable unless you are deliberately renumbering.
 - **Version:** `SKILL.md` frontmatter has a `version:` field, `README.md` has a "Version History" section, and `.claude-plugin/plugin.json` has a `version` field. Bump them together so package metadata matches the skill. (`marketplace.json` intentionally omits a version so `plugin.json` stays the package source of truth.)
 - **Compatibility:** keep install and usage language harness-neutral. The skill should work in any agent harness that can load Markdown skill instructions; Claude Code, OpenCode, Codex, and other harnesses are examples, not limits.
 - **Non-obvious fixes:** if you change the prompt to handle a tricky failure mode (a repeated mis-edit, an unexpected tone shift), add a short note to the README version history explaining what was fixed and why.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
-## 33 Patterns Detected (with Before/After Examples)
+## 34 Patterns Detected (with Before/After Examples)
 
 ### Content Patterns
 
@@ -141,6 +141,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 31 | **Manufactured punchlines / staccato drama** | "It had no preference. No prior. No nostalgia." | Use varied sentence lengths and concrete claims |
 | 32 | **Aphorism formulas** | "Symmetry is the language of trust" | Replace the formula with the actual claim |
 | 33 | **Conversational rhetorical openers** | "Honestly? It depends..." | Remove the fake-candid setup |
+| 34 | **Catalog sentences after a colon** | "The value is clear: speed, trust, and alignment" | Name the actor and action |
 
 ### Communication Patterns
 
@@ -193,6 +194,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ## Version History
 
+- **2.8.3** - Added pattern #34 for catalog sentences after a colon, where a leading claim introduces a polished list of abstract benefits. This catches lines like "the value is clear: speed, trust, and alignment" without banning useful colons.
 - **2.8.2** - Replaced the full before/after example with a first-person Lisbon trip recap. The after now keeps the same topic, perspective, and rough length as the before while removing the AI tells without becoming clipped or slogan-like. No change to the 33 patterns.
 - **2.8.1** - Added cross-agent installation docs, optional Claude Code plugin packaging, and a compact secondhand-text false-positive guard. No change to the 33 patterns.
 - **2.8.0** - Added style/cadence patterns #31-33 for manufactured punchlines, aphorism formulas, and conversational rhetorical openers; expanded #20 to catch offer-to-continue chatbot closers. 33 patterns total.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: humanizer
-version: 2.8.2
+version: 2.8.3
 description: |
   Remove signs of AI-generated writing from text. Use when editing or reviewing
   text to make it sound more natural and human-written. Based on Wikipedia's
   comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
   inflated symbolism, promotional language, superficial -ing analyses, vague
-  attributions, em dash overuse, rule of three, AI vocabulary words, passive
-  voice, negative parallelisms, and filler phrases.
+  attributions, em dash overuse, rule of three, catalog-sentence colon lists,
+  AI vocabulary words, passive voice, negative parallelisms, and filler
+  phrases.
 license: MIT
 compatibility: any-agent
 allowed-tools:
@@ -219,7 +220,6 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 **After:**
 > The event includes talks and panels. There's also time for informal networking between sessions.
-
 
 ### 11. Elegant Variation (Synonym Cycling)
 
@@ -518,6 +518,25 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 
 **After:**
 > Whether it's worth the price depends on how often you'll use it.
+
+
+### 34. Catalog Sentences After a Colon
+
+**Problem:** LLMs often write a leading claim, add a colon, then pack the real point into a tidy catalog of verbs or nouns. This is especially obvious when the sentence also has a rule-of-three rhythm, such as "control X, coordinate Y, and prove Z." The colon turns the sentence into slide copy. It also hides the concrete actor and action.
+
+**Before:**
+> The platform gives teams a verifiable action layer: control what runs, coordinate what carries forward, and prove what happened.
+
+**After:**
+> The platform records each agent action so teams can decide what runs, carry context into later work, and prove what happened.
+
+**Before:**
+> The value proposition is clear: faster onboarding, stronger governance, and better alignment.
+
+**After:**
+> The product shortens onboarding and gives managers a clearer way to review work.
+
+**Rule:** Do not ban colons outright. Keep a colon when it introduces a true explanation, command, definition, or code-oriented label. Rewrite it when it introduces a polished catalog, especially a list of abstract benefits. Treat this as a cluster tell, not proof by itself.
 
 
 ## DETECTION GUIDANCE


### PR DESCRIPTION
## What
Adds pattern #34 for a sentence shape where an LLM writes a lead-in claim, a colon, and a polished catalog of abstract benefits.

This is related to the existing rule-of-three and inline-header list patterns, but it catches the prose form rather than bullet labels.

## Why
This is not a blanket colon ban or phrase ban. It is meant for the cluster where the colon introduces the sentence's real point, the list is abstract benefit language, and the line often overlaps with rule-of-three rhythm.

The false-positive rule keeps ordinary definitions, commands, labels, and code-oriented colons intact.

## Prior feedback
I saw the feedback on #132 about overfit phrase guardrails. This patch avoids that shape: it adds a real numbered pattern, keeps README, version, and plugin metadata in sync, and describes a reusable sentence pattern rather than banning a common technical phrase.