### PR TITLE
docs: fix curly-quotes example in README pattern table

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 | 16 | **Inline-header lists** | "**Performance:** Performance improved" | Convert to prose |
 | 17 | **Title Case Headings** | "Strategic Negotiations And Partnerships" | "Strategic negotiations and partnerships" |
 | 18 | **Emojis** | "🚀 Launch Phase: 💡 Key Insight:" | Remove emojis |
-| 19 | **Curly quotes** | `said “the project”` | `said “the project”` |
+| 19 | **Curly quotes** | `said “the project”` | `said "the project"` |
 | 26 | **Hyphenated word pairs** | “cross-functional, data-driven, client-facing” | Drop hyphens on common word pairs |
 | 27 | **Persuasive authority tropes** | "At its core, what matters is..." | State the point directly |
 | 28 | **Signposting announcements** | "Let's dive in", "Here's what you need to know" | Start with the content |


### PR DESCRIPTION
## What

Pattern #19 ("Curly quotes") in the README's pattern table showed curly quotes in **both** the Before and After columns:

| # | Pattern | Before | After |
|---|---------|--------|-------|
| 19 | **Curly quotes** | `said “the project”` | `said “the project”` |  ← After was also curly |

Since the entire point of the pattern is converting curly quotes → straight quotes, the After column now uses straight quotes, matching the source-of-truth example in `SKILL.md` (§19):

> **Before:** He said “the project is on track” but others disagreed.
> **After:** He said "the project is on track" but others disagreed.

## Why

Per `AGENTS.md`, `SKILL.md` and `README.md` must stay in sync. The README example contradicted the skill and the pattern's own stated purpose. This is a docs-only, single-line change — no patterns added, removed, or renumbered, so no version bump or cross-references are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)