### PR TITLE
Extend §7 AI vocabulary with "quietly"

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Rewrites follow a no-fabrication rule: they never add facts, names, dates, or ci
 
 | # | Pattern | Before | After |
 |---|---------|--------|-------|
-| 7 | **AI vocabulary** | "Actually... additionally... testament... landscape... showcasing" | "also... remain common" |
+| 7 | **AI vocabulary** | "Actually... additionally... quietly... testament... landscape... showcasing" | "also... remain common" |
 | 8 | **Copula avoidance** | "serves as... features... boasts" | "is... has" |
 | 9 | **Negative parallelisms / tailing negations** | "It's not just X, it's Y", "..., no guessing" | State the point directly |
 | 10 | **Rule of three** | "innovation, inspiration, and insights" | Use natural number of items |

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,7 +111,7 @@ When voice is appropriate, avoid uniform sentence structures, bloodless neutrali
 
 ### 7. Overused "AI Vocabulary" Words
 
-**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+**High-frequency AI words:** Actually, additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, quietly, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
 **Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
 **Before:**
 > Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.


### PR DESCRIPTION
## Summary
- Adds `quietly` to the §7 high-frequency AI vocabulary list in `SKILL.md` (alphabetically between `pivotal` and `showcase`)
- Updates README pattern table row 7 to match

## Why
AI overuses "quietly" as a significance adverb ("quietly building," "quietly reshaping") to imply understated importance without evidence. 

Sources:

- https://tropes.fyi/tropes/quietly-adverb
- https://www.linkedin.com/posts/eliana-cline_genuine-question-why-is-claude-fixated-on-activity-7459884566405890049-E2uB
- https://sulliwrites.medium.com/if-i-see-the-words-quiet-quietly-one-more-time-im-going-to-lose-it-dd0c6206bf96


## Scope
Same shape as merged #77: extends existing pattern 7 only. No new pattern number, no version bump (`validate-package.py` still reports v2.9.1).

## Test plan
- [x] `python3 scripts/validate-package.py`