### PR TITLE
Add shadowboxing and editorial scar tissue patterns (v2.10.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "humanizer",
   "description": "Remove signs of AI-generated writing from text, making it sound more natural and human. Based on Wikipedia's \"Signs of AI writing\" guide.",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "author": {
     "name": "blader",
     "url": "https://github.com/blader"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ A portable agent skill implemented entirely as Markdown. The runtime artifact is
 
 `SKILL.md` and `README.md` must stay in sync. When you change behavior or content:
 
-- **Patterns:** the skill currently defines **33 numbered patterns**. If you add, remove, or renumber any, update the README pattern table, its "N Patterns Detected" heading, and every cross-reference in the same change. Keep numbering stable unless you are deliberately renumbering.
+- **Patterns:** the skill currently defines **35 numbered patterns**. If you add, remove, or renumber any, update the README pattern table, its "N Patterns Detected" heading, and every cross-reference in the same change. Keep numbering stable unless you are deliberately renumbering.
 - **Version:** `SKILL.md` frontmatter stores the version under `metadata.version`, `README.md` has a "Version History" section, and `.claude-plugin/plugin.json` has a `version` field. Bump them together so package metadata matches the skill. Keep the skill version under `metadata`; a top-level `version` key is not portable across Agent Skills hosts. (`marketplace.json` intentionally omits a version so `plugin.json` stays the package source of truth.)
 - **Compatibility:** keep install and usage language harness-neutral. The skill should work in any agent harness that can load Markdown skill instructions; Claude Code, OpenCode, Codex, and other harnesses are examples, not limits.
 - **Validation:** run `python3 scripts/validate-package.py`, `npx skills add . --list`, and `claude plugin validate .` before publishing.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Rewrites follow a no-fabrication rule: they never add facts, names, dates, or ci
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
-## 33 Patterns Detected (with Before/After Examples)
+## 35 Patterns Detected (with Before/After Examples)
 
 ### Content Patterns
 
@@ -153,6 +153,8 @@ Rewrites follow a no-fabrication rule: they never add facts, names, dates, or ci
 | 31 | **Manufactured punchlines / staccato drama** | "It had no preference. No prior. No nostalgia." | Use varied sentence lengths and concrete claims |
 | 32 | **Aphorism formulas** | "Symmetry is the language of trust" | Replace the formula with the actual claim |
 | 33 | **Conversational rhetorical openers** | "Honestly? It depends..." | Remove the fake-candid setup |
+| 34 | **Shadowboxing** | "This isn't mainly about prompt length..." | Cut the unraised objection; restate any claim it concedes |
+| 35 | **Editorial scar tissue** | "A tempting option would be to..., but" | Cut the phantom alternative; keep options a reader would actually weigh |
 
 ### Communication Patterns
 
@@ -207,6 +209,7 @@ Rewrites follow a no-fabrication rule: they never add facts, names, dates, or ci
 
 ## Version History
 
+- **2.10.0** - Added patterns #34 (shadowboxing) and #35 (editorial scar tissue) for drafting-conversation residue: unattributed meta-level negations answering objections nobody raised, and phantom "tempting alternative" rebuttals recycled from the model's own corrected mistakes. Both come with false-positive guards protecting real disclaimers, scoping statements, engaged objections, and alternatives a reader would actually weigh (fixes #198). Also expanded #24 to catch accumulated fairness clauses from iterative editing, and changed the revision step to rewrite from the point rather than patch flagged phrases, since patches are how scar tissue forms. 35 patterns total.
 - **2.9.1** - Improved distribution and portability: removed nonportable frontmatter and tool preapprovals, made global installation the documented default, added package validation, and removed the duplicated long-form example from the runtime prompt. No change to the 33 patterns.
 - **2.9.0** - Added a no-fabrication rule: rewrites may not invent facts, names, dates, or citations not present in the source, and every example that modeled invented specifics was re-cut to use only source information (fixes #187). Replaced paragraph-count parity with an information-over-shape rule, made a user's voice sample outrank the em dash ban, and added invocation modes (pasted text / file / embedded). No change to the 33 patterns.
 - **2.8.3** - Moved the skill version from the unsupported top-level frontmatter key to `metadata.version` for Agent Skills and Claude compatibility. No change to the 33 patterns.

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ description: |
   voice, negative parallelisms, and filler phrases.
 license: MIT
 metadata:
-  version: "2.9.1"
+  version: "2.10.0"
 ---
 
 # Humanizer: Remove AI Writing Patterns
@@ -265,7 +265,9 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 - "It is important to note that the data shows" → "The data shows"
 
 ### 24. Excessive Hedging
-**Problem:** Over-qualifying statements.
+
+**Phrases to watch:** to be fair, it's also possible, could potentially, might arguably, in some cases it may, this is an inference
+**Problem:** Over-qualifying statements. Iterative editing compounds this: each pass softens an overstatement, then softens the qualifier, until nearly every conclusion carries a fairness clause and the prose reads like it was negotiated. A claim earns one honest qualifier at most; a caveat that exists only because an earlier draft overreached should be cut along with the overreach.
 **Before:**
 > It could potentially possibly be argued that the policy might have some effect on outcomes.
 **After:**
@@ -352,6 +354,28 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 **After:**
 > Whether it's worth the price depends on how often you'll use it.
 
+### 34. Shadowboxing (Defending Against Unraised Objections)
+
+**Phrases to watch:** This isn't (mainly/really) about, I'm not saying/arguing/trying to, To be clear, Don't get me wrong, This is not to say, You could argue/frame this differently but, Some might say... but
+**Problem:** LLMs rebut objections nobody in the published text raised, usually leftovers from the drafting conversation. The tell is a negation about the piece's own aims or the author's intent that is unattributed, dropped within a sentence, and about a topic that appears nowhere else in the piece. An object-level negation ("the API is not thread-safe") is a claim, not shadowboxing.
+**Before:**
+> This isn't mainly about prompt length, and I'm not arguing that documentation doesn't matter. You could categorize the problem another way, but the issue is whether the agent can use the instruction when it acts.
+**After:**
+> The issue is whether the agent can use the instruction when it acts.
+
+(Cut only the defensive clause and leave the surrounding argument alone. A defense can smuggle in a real claim: if "I'm not arguing documentation doesn't matter" concedes a point the piece actually uses, restate it affirmatively instead of deleting it. An objection the text attributes to someone or genuinely engages stays; §9 governs its phrasing.)
+
+### 35. Editorial Scar Tissue (Phantom Alternatives)
+
+**Phrases to watch:** A tempting option/approach would be, One might be tempted to, An obvious approach would be, You might think... but, It would be easy to just, Some would suggest
+**Problem:** The model recycles its own corrected mistakes as strawmen: mid-argument the text rebuts a "tempting" alternative no reader would consider, drops it, then does it again later on an unrelated tangent. Each digression is a scar from the drafting conversation, where the option was live until a human killed it. The tells: the alternative is attributed to no one, appears nowhere else in the piece, and is dismissed in a clause or two.
+**Before:**
+> Session tokens are rotated every 24 hours. A tempting approach would be to rotate them by restarting the auth service on a cron job, but that would drop every active session. Rotation happens in place, and clients refresh transparently.
+**After:**
+> Session tokens are rotated every 24 hours, in place, and clients refresh transparently.
+
+(Cut the whole digression and let the surrounding sentences rejoin; if the rebuttal smuggles in a real constraint the piece uses, restate it affirmatively. One phantom rebuttal is ambiguous; several on unrelated tangents is the confession. The general test: if you can explain which previous edit caused a sentence to exist, rather than what new information it contributes, it is scar tissue — rewrite the paragraph from its point instead of patching the sentence.)
+
 ## DETECTION GUIDANCE
 
 ### What NOT to flag (false positives)
@@ -368,6 +392,8 @@ A clean human writer can hit several of the patterns above without any AI involv
 - **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
 - **One short emphatic sentence.** Humans use clipped sentences to land a point. Flag staccato drama only when several short fragments appear in a row and inflate the tone.
 - **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
+- **Disclaimers and scoping that do real work.** "This guide does not cover Windows," legal and safety notices, and corrections of misconceptions readers actually hold are content, not shadowboxing (§34). So are attributed objections the text engages, replies and FAQs that answer someone by design, and a single self-aware aside in a voiced piece.
+- **Alternatives a reader would actually reach for.** Design docs weighing real options, tutorials warning against genuinely tempting mistakes, and essays that steelman before disagreeing are content, not scar tissue (§35). The tell is the implausible alternative dispatched mid-flow and never revisited.
 - **Unsourced claims.** Most of the web is unsourced. Lack of citations doesn't prove anything.
 - **Correct, complex formatting.** Visual editors and templates produce clean output without any AI.
 - **Secondhand text.** Do not rewrite watched phrases inside quotations, titles, proper names, or examples where the phrase is being discussed rather than used.
@@ -401,7 +427,7 @@ When you see these, lean toward leaving the prose alone — they are evidence of
 1. Read the input carefully and identify every instance of the patterns above.
 2. Write a **draft rewrite**. Check that it reads naturally aloud, varies sentence length, prefers specific details and simple constructions (is/are/has), and keeps the appropriate register.
 3. Ask two questions: **"What makes the below so obviously AI generated?"** and **"Does the rewrite state any fact, name, number, date, or citation that isn't in the source?"** Answer briefly. A fabrication is a defect even when it sounds more human than the vague original.
-4. Revise into a **final rewrite** that addresses them and contains no em or en dashes (see §14).
+4. Revise into a **final rewrite** that addresses them and contains no em or en dashes (see §14). Revise by re-saying the point, not by patching the flagged phrase: a patch that leaves the sentence heavier than a person would write it is new scar tissue (§35), and enough of them make the prose read as cross-examined. When a sentence resists repair, ask "how would a person naturally make this point?" and rewrite the paragraph from that.
 
 In pasted-text mode, deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optionally) a short summary of changes. In file and embedded modes, run the same loop but deliver only what the mode calls for (see Invocation Modes).
 

--- a/scripts/validate-package.py
+++ b/scripts/validate-package.py
@@ -46,14 +46,14 @@ pattern_numbers = [
     int(number)
     for number in re.findall(r"(?m)^### ([0-9]+)\. ", SKILL)
 ]
-if pattern_numbers != list(range(1, 34)):
-    raise SystemExit(f"Expected patterns 1-33, found {pattern_numbers}")
+if pattern_numbers != list(range(1, 36)):
+    raise SystemExit(f"Expected patterns 1-35, found {pattern_numbers}")
 
 readme_numbers = {
     int(number) for number in re.findall(r"(?m)^\| ([0-9]+) \|", README)
 }
-if readme_numbers != set(range(1, 34)):
-    raise SystemExit("README pattern table must contain patterns 1-33")
+if readme_numbers != set(range(1, 36)):
+    raise SystemExit("README pattern table must contain patterns 1-35")
 
 if len(SKILL.splitlines()) > 500:
     raise SystemExit("SKILL.md exceeds the 500-line portability budget")


### PR DESCRIPTION
Fixes #198.

Adds two patterns for drafting-conversation residue: prose that leans on context only the drafting session had, so it reads defensive or digressive to a cold reader.

## Pattern 34: Shadowboxing (Defending Against Unraised Objections)

The pattern from #198: meta-level negations about the piece's own aims or the author's intent ("This isn't mainly about X", "I'm not arguing Y") that answer objections nobody in the published text raised.

Two changes from the issue as filed:

- The "would a cold reader arrive at this objection?" test isn't operational: the editor usually can't see the drafting conversation either. Detection instead uses in-text signals — the negation is meta-level (never object-level claims like "the API is not thread-safe"), unattributed, dropped within a sentence, and about a topic that appears nowhere else in the piece.
- The fix guidance resolves a conflict with the skill's claim-preservation rule. "I'm not arguing documentation doesn't matter" embeds a real position; when the piece uses that position, the editor restates it affirmatively instead of deleting it, and deletes only pure not-X clauses. Attributed or genuinely engaged objections stay, with §9 governing their phrasing.

## Pattern 35: Editorial Scar Tissue (Phantom Alternatives)

A sibling with the same root cause and a different surface: mid-argument, the text rebuts a "tempting" alternative no reader would consider, drops it, then does it again later on an unrelated tangent. The alternative is usually the model's own corrected mistake, recycled as a strawman — a scar from the drafting conversation, where the option was live until a human killed it. Tells: attributed to no one, appears nowhere else in the piece, dismissed in a clause or two.

The general test, which covers both patterns: if you can explain which previous edit caused a sentence to exist, rather than what new information it contributes, it's scar tissue.

Together with §30 (diff-anchored writing), these cover the three ways text leans on invisible history: commit history, drafting objections, and corrected mistakes.

## False-positive guards

"This isn't about X" in the wild is usually legitimate, so both patterns come with guards in "What NOT to flag": scoping statements ("This guide does not cover Windows"), legal and safety disclaimers, corrections of misconceptions readers actually hold, attributed or engaged objections, replies and FAQs that answer someone by design, voice-bearing asides, and alternatives a reader would actually reach for (design docs weighing real options, tutorials warning against genuinely tempting mistakes, essays that steelman).

## Related changes

- §24 (Excessive Hedging) gains watch phrases and the accumulation dynamic: iterative editing stacks fairness clauses ("to be fair", "it's also possible") until every conclusion reads as negotiated. A claim earns one honest qualifier at most; a caveat that exists only because an earlier draft overreached gets cut with the overreach.
- The revision step in Process and Output now says to rewrite from the point rather than patch the flagged phrase. Sentence-by-sentence patching is how scar tissue forms, and the skill's own draft → audit → final loop is not exempt.
- Maintenance contract: README heading and table updated to 35 patterns, AGENTS.md count updated, version bumped to 2.10.0 in all three synced places, and the validator's pattern ranges extended. `python3 scripts/validate-package.py` passes; SKILL.md is at 438 of the 500-line budget.
