### PR TITLE
Pin CI dependencies to exact versions and commit SHAs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,11 +12,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
       - name: Check package files
@@ -25,5 +25,5 @@ jobs:
         run: npx --yes skills@1.5.20 add . --list
       - name: Check Claude marketplace
         run: |
-          npm install --global @anthropic-ai/claude-code
+          npm install --global @anthropic-ai/claude-code@2.1.237
           claude plugin validate .


### PR DESCRIPTION
Two hardening gaps in `.github/workflows/validate.yml`, found in a full-repo review:

1. **Unpinned npm install.** `npm install --global @anthropic-ai/claude-code` resolved to whatever `latest` pointed at on each run, so every pull request and push executed a freshly published package (plus its dependency tree's lifecycle scripts) on the runner, and the same commit could pass one day and fail the next when a new release changed validation rules. The adjacent step already pins `skills@1.5.20`. Now pinned to `2.1.237` (current latest at the time of this PR); bump it deliberately in a commit when you want new validation behavior.

2. **Mutable action tags.** `actions/checkout@v4`, `setup-node@v4`, and `setup-python@v5` are tag references, and tags can be retargeted. Now pinned to full commit SHAs per GitHub's hardening guidance, with the human-readable version in a trailing comment so Dependabot can still bump them. SHAs verified against each action repo (checkout v4.4.0, setup-node v4.4.0, setup-python v5.6.0); same major versions as before, so no behavior change.

The workflow's trigger and permission choices (`pull_request`, workflow-level `contents: read`) were already correct and are untouched. No version bump since this changes CI only, not the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)