### PR TITLE
Sync pattern grouping and protect inline code spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,12 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 | 17 | **Title case in headings** | "Strategic Negotiations And Partnerships" | "Strategic negotiations and partnerships" |
 | 18 | **Emojis** | "🚀 Launch Phase: 💡 Key Insight:" | Remove emojis |
 | 19 | **Curly quotes** | `said “the project”` | `said "the project"` |
-| 26 | **Too many hyphenated word pairs** | “cross-functional, data-driven, client-facing” | Keep only the hyphens grammar needs |
+
+### More style patterns
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 26 | **Too many hyphenated word pairs** | "cross-functional, data-driven, client-facing" | Keep only the hyphens grammar needs |
 | 27 | **A fake deeper truth** | "At its core, what matters is..." | State the point directly |
 | 28 | **Announcing the next point** | "Let's dive in", or "one thing that bit me" | Start with the content |
 | 29 | **A heading repeated below itself** | "## Performance" + "Speed matters." | Let the heading do the work |

--- a/SKILL.md
+++ b/SKILL.md
@@ -180,7 +180,7 @@ Do not ban the repeated word. Fix the repeated sentence pattern. The remaining s
 
 ### 14. Em and en dashes
 
-**Rule:** The final rewrite must not contain em dashes (—) or en dashes (–), unless the writer's sample uses them. Replace a dash with a period, comma, colon, or parentheses, or rewrite the sentence. Also check for spaced dashes (` — `) and double hyphens (` -- `) used as dashes.
+**Rule:** The final rewrite must not contain em dashes (—) or en dashes (–), unless the writer's sample uses them. Replace a dash with a period, comma, colon, or parentheses, or rewrite the sentence. Also check for spaced dashes (` — `) and double hyphens (` -- `) used as dashes. Do not change dashes or hyphens inside code blocks, inline code spans, commands, paths, or URLs.
 **Before:**
 > The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
 **After:**
@@ -289,6 +289,8 @@ Before returning the rewrite, search for `—` and `–`. Remove each one unless
 > The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
 **After:**
 > (Cut the paragraph. End on the last concrete fact instead of a send-off. If the source states real plans, use those.)
+
+## More style patterns
 
 ### 26. Too many hyphenated word pairs
 
@@ -433,7 +435,7 @@ These details often carry the writer's voice. Keep them unless they hurt the mea
 
 **Pasted text (default).** Return the draft, a short list of remaining AI patterns, and the final rewrite.
 
-**File mode.** When the user names a file, run the full rewrite process but write only the final text to the file. Change prose only. Keep code blocks, YAML metadata, data, and link targets unchanged. Then give the user a short summary.
+**File mode.** When the user names a file, run the full rewrite process but write only the final text to the file. Change prose only. Keep code blocks, inline code spans, exact identifiers, commands, paths, YAML metadata, data, and link targets unchanged. Then give the user a short summary.
 
 **Embedded mode.** When another task uses this skill for a pull request, commit message, or document, return only the final text.
 


### PR DESCRIPTION
Three related documentation and prompt fixes from a full-repo review:

1. **Pattern grouping drift.** SKILL.md's "## Filler and hedging" heading covered patterns 23 through 35, but ten of those (26-35, e.g. §29 repeated headings, §30 previous-version prose) are not filler or hedging, and the README lists them under "Style patterns". AGENTS.md requires keeping the two files in sync, and the validator only checks numbering, so this drift passed CI. Both files now use a "More style patterns" section for 26-35 ("Filler and hedging" keeps 23-25). The README's style table is split at the same boundary so the two documents use one term.

2. **Inline code spans were rewritable in file mode.** File mode's preservation list named "code blocks, YAML metadata, data, and link targets" but not inline code spans, while §14 targets ` -- ` and §19 straightens curly quotes. Humanizing a Markdown file whose prose contains `git checkout -- .` or a curly-quoted identifier could silently corrupt it. The list now uses AGENTS.md's own wording ("inline code spans, exact identifiers, commands, paths"), and §14 states it does not reach into code blocks, inline code spans, commands, paths, or URLs.

3. **Curly quotes in README row 26.** The Before cell for pattern 26 was wrapped in curly quotes in a plain table cell, the exact artifact pattern 19 removes (row 19's curly quotes are deliberate and sit in a code span; row 26's were not). Now straight quotes.

Validator invariants checked: SKILL.md is 458 lines (limit 500), patterns 1-35 remain sequential, all 35 README rows present. No version bump here to avoid colliding with #233; happy to fold a release note into whichever lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)