### PR TITLE
Harden validate-package.py and document agents/openai.yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Keep the skill portable. Do not write instructions that limit it to one or two a
 - `README.md` explains installation, use, patterns, and version history.
 - `.claude-plugin/plugin.json` describes the Claude plugin and points its skill loader at the root `SKILL.md`.
 - `.claude-plugin/marketplace.json` lets users add this repo as a Claude marketplace.
+- `agents/openai.yaml` holds the display name, short description, and default prompt for OpenAI-compatible agents.
 - `scripts/validate-package.py` checks package files and shared values.
 
 ## Rules for changes

--- a/scripts/validate-package.py
+++ b/scripts/validate-package.py
@@ -9,11 +9,23 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent.parent
+
+
+def read_package_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise SystemExit(f"Cannot read {path.relative_to(ROOT)}: {error}")
+
+
 SKILL_PATH = ROOT / "SKILL.md"
-SKILL = SKILL_PATH.read_text(encoding="utf-8")
-README = (ROOT / "README.md").read_text(encoding="utf-8")
-AGENTS = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
-PLUGIN = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+SKILL = read_package_file(SKILL_PATH)
+README = read_package_file(ROOT / "README.md")
+AGENTS = read_package_file(ROOT / "AGENTS.md")
+try:
+    PLUGIN = json.loads(read_package_file(ROOT / ".claude-plugin" / "plugin.json"))
+except json.JSONDecodeError as error:
+    raise SystemExit(f"Fix the JSON in .claude-plugin/plugin.json: {error}")
 
 
 def require_match(match: re.Match[str] | None, message: str) -> re.Match[str]:
@@ -32,8 +44,8 @@ for unsupported_field in ("compatibility:", "allowed-tools:"):
         raise SystemExit(f"Remove unsupported YAML field: {unsupported_field[:-1]}")
 
 skill_version = require_match(
-    re.search(r'(?m)^\s+version:\s*["\']([^"\']+)["\']\s*$', yaml_metadata),
-    "Add metadata.version to SKILL.md",
+    re.search(r'(?m)^\s+version:\s*["\']?([0-9]+\.[0-9]+\.[0-9]+)["\']?\s*$', yaml_metadata),
+    "Add metadata.version to SKILL.md as a three-part version",
 ).group(1)
 readme_version = require_match(
     re.search(r"(?m)^- \*\*([0-9]+\.[0-9]+\.[0-9]+)\*\*", README),
@@ -76,11 +88,13 @@ pattern_numbers = [
 if pattern_numbers != list(range(1, 36)):
     raise SystemExit(f"Number SKILL.md patterns from 1 through 35: {pattern_numbers}")
 
-readme_numbers = {
+readme_numbers = [
     int(number) for number in re.findall(r"(?m)^\| ([0-9]+) \|", README)
-}
-if readme_numbers != set(range(1, 36)):
-    raise SystemExit("List patterns 1 through 35 in the README table")
+]
+if sorted(readme_numbers) != list(range(1, 36)):
+    raise SystemExit(
+        f"List patterns 1 through 35 once each in the README table: {sorted(readme_numbers)}"
+    )
 
 if len(SKILL.splitlines()) > 500:
     raise SystemExit("Keep SKILL.md at 500 lines or fewer")


### PR DESCRIPTION
Four small robustness fixes to the package checks, found in a full-repo review:

1. **Plain-language errors for unreadable files.** The four reads at the top of `validate-package.py` were the only failures that produced a raw traceback (`FileNotFoundError`, `JSONDecodeError`) instead of the plain-language `SystemExit` every other check uses. A missing package file is exactly the condition the validator exists to report. Reads now go through a helper, and malformed `plugin.json` gets its own message.
2. **Unquoted `metadata.version` no longer fails as missing.** The regex required quotes, so valid YAML like `version: 2.11.2` exited with "Add metadata.version to SKILL.md" even though the field was present. Quotes are now optional and the value must be a three-part version.
3. **Duplicate README rows now fail.** The README pattern check collapsed numbers into a set, so a duplicated row (say pattern 26 listed twice) passed. It now compares a sorted list against 1..35 and the message names the numbers it found, matching how the SKILL.md check already works.
4. **`agents/openai.yaml` documented.** It was the one tracked file that appeared in no documentation and no check; AGENTS.md's Key files list now includes it. No validator check added for its contents since the repo does not define which loader consumes it.

Verified by running the script against the repo (passes, "Humanizer package v2.11.2 is valid") and against four induced failures in a scratch copy: unquoted version (now passes), duplicated row 26 (fails, lists the duplicate), deleted README.md (plain message, exit 1), malformed plugin.json (plain message, exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)