### PR TITLE
Strengthen guidance against repetitive not-X-but-Y phrasing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "humanizer",
   "description": "Rewrite AI-sounding text so it reads naturally without changing what it says.",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "author": {
     "name": "blader",
     "url": "https://github.com/blader"

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 |---|---------|--------|-------|
 | 7 | **Overused AI words** | "Actually... additionally... gated on... quietly... testament... landscape... showcasing" | "also... needs... remain common" |
 | 8 | **Avoiding is and are** | "serves as... features... boasts" | "is... has" |
-| 9 | **Not X but Y and clipped endings** | "It's not just X, it's Y", "..., no guessing" | State the point directly |
+| 9 | **Not X but Y and clipped endings** | "not a minor update, but a complete rethinking", "..., no guessing" | State the point directly |
 | 10 | **Forced groups of three** | "innovation, inspiration, and insights" | Use the number of items the meaning needs |
 | 11 | **Changing names and repeated openings** | "protagonist... main character... hero" or "She noted... She noted... She filed..." | Use one name or merge the repeated sentences |
 | 12 | **False from X to Y ranges** | "from the Big Bang to dark matter" | List the topics directly |
@@ -154,6 +154,7 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 <details>
 <summary>Show release notes</summary>
 
+- **2.11.3** - Strengthened pattern #9 against repeated "not X, but Y" phrasing. Keep it only when the contrast adds meaning. 35 patterns total.
 - **2.11.2** - Removed the plugin symlink and separate Claude Desktop package. Current Claude Code loads the root `SKILL.md` directly, so GitHub's source ZIP now works in Claude Desktop. No change to the 35 patterns.
 - **2.11.1** - Added a Claude Desktop-ready release package with one regular `humanizer/SKILL.md` file. GitHub's source archive still keeps the plugin symlink (fixes #224). No change to the 35 patterns.
 - **2.11.0** - Rewrote all repo guidance, descriptions, checks, and skill instructions in Plain Language. Kept all 35 patterns and their behavior.

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: |
   voice, filler, or chatbot artifacts. Based on Wikipedia's "Signs of AI writing."
 license: MIT
 metadata:
-  version: "2.11.2"
+  version: "2.11.3"
 ---
 
 # Humanizer: remove AI writing patterns
@@ -128,17 +128,24 @@ Add details such as dates or public actions only when they come from the source 
 > Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
 
 ### 9. Not X but Y and clipped negative endings
-**Problem:** AI writing overuses forms such as "Not only...but..." and "It's not just X, it's Y."
+**Words to watch:** not X, but Y; not just X, but Y; not only X, but Y; not merely X, but Y; it's not X, it's Y
+**Problem:** AI writing overuses a negative claim followed by a more emphatic replacement. It uses forms such as "Not only...but..." and "It's not just X, it's Y" as a default way to add weight. State the point directly instead.
 
 It also adds clipped endings such as "no guessing" instead of writing a clear clause.
 **Before:**
 > It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
 **After:**
 > The heavy beat adds to the aggressive tone.
+**Before:**
+> This is not a minor update, but a complete rethinking of how teams work.
+**After:**
+> The update changes how teams work.
 **Before (tailing negation):**
 > The options come from the selected item, no guessing.
 **After:**
 > The options come from the selected item without forcing the user to guess.
+
+Keep the form when the negative clause corrects a real misconception or makes a useful contrast. Do not use it only to make an ordinary claim sound larger.
 
 ### 10. Forced groups of three
 **Problem:** AI writing often forces ideas into groups of three to sound complete.


### PR DESCRIPTION
## Summary

- make pattern 9 explicitly flag repeated not-X-but-Y constructions
- add a direct before-and-after rewrite example
- preserve meaningful corrections and genuine contrasts