### PR TITLE
Reject top-level version in package validation

### DIFF
--- a/scripts/validate-package.py
+++ b/scripts/validate-package.py
@@ -27,7 +27,7 @@ yaml_metadata = require_match(
     "SKILL.md must begin with YAML metadata",
 ).group(1)
 
-for unsupported_field in ("compatibility:", "allowed-tools:"):
+for unsupported_field in ("version:", "compatibility:", "allowed-tools:"):
     if re.search(rf"(?m)^{re.escape(unsupported_field)}", yaml_metadata):
         raise SystemExit(f"Remove unsupported YAML field: {unsupported_field[:-1]}")
 


### PR DESCRIPTION
## Problem

`AGENTS.md` requires the skill version to live under `metadata.version` and forbids a top-level `version`. This layout was adopted after #41 because `version` is not a supported top-level Agent Skills frontmatter field.

The package validator currently rejects two disallowed top-level fields but omits `version`. Adding a duplicate top-level version therefore still reports the package as valid.

## Change

Add `version:` to the existing unsupported-field check. The check is anchored at the start of a line, so the valid indented `metadata.version` remains allowed.

## Verification

- Reproduced on `main`: a duplicate top-level `version` exits successfully.
- With this change, the same fixture exits with `Remove unsupported YAML field: version`.
- `python scripts/validate-package.py`
- `npx --yes skills@1.5.20 add . --list`
- `claude plugin validate .`
- `git diff --check`

Developed with AI assistance (Codex).
