### PR TITLE
Preserve ranking and simultaneity claims

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "humanizer",
   "description": "Rewrite AI-sounding text so it reads naturally without changing what it says.",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "author": {
     "name": "blader",
     "url": "https://github.com/blader"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 <details>
 <summary>Show release notes</summary>
 
+- **2.11.3** - Strengthened the step 3 fact-integrity check to explicitly guard against silent deletion of ranking claims (words such as *most*, *least*, *first*, *only*), superlatives, and simultaneity assertions (words such as *simultaneously*, *at once*, *both*). Patterns §10, §15, and §24 can remove these words while appearing to remove only shape (fixes #212). No change to the 35 patterns.
 - **2.11.2** - Removed the plugin symlink and separate Claude Desktop package. Current Claude Code loads the root `SKILL.md` directly, so GitHub's source ZIP now works in Claude Desktop. No change to the 35 patterns.
 - **2.11.1** - Added a Claude Desktop-ready release package with one regular `humanizer/SKILL.md` file. GitHub's source archive still keeps the plugin symlink (fixes #224). No change to the 35 patterns.
 - **2.11.0** - Rewrote all repo guidance, descriptions, checks, and skill instructions in Plain Language. Kept all 35 patterns and their behavior.

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: |
   voice, filler, or chatbot artifacts. Based on Wikipedia's "Signs of AI writing."
 license: MIT
 metadata:
-  version: "2.11.2"
+  version: "2.11.3"
 ---
 
 # Humanizer: remove AI writing patterns
@@ -443,7 +443,7 @@ These details often carry the writer's voice. Keep them unless they hurt the mea
 2. Write a draft. Read it aloud. Check the rhythm, details, simple verbs such as *is* and *has*, and the right level of formality.
 3. Ask two questions:
    - **"What still sounds AI-generated?"**
-   - **"Did the rewrite add or remove any fact, name, number, date, quote, citation, ranking, or other claim?"**
+   - **"Did the rewrite add or remove any fact, name, number, date, quote, citation, ranking, or other claim?"** Also check that the source's ranking claims (words such as *most*, *least*, *first*, *only*), superlatives, and simultaneity assertions (words such as *simultaneously*, *at once*, *both*) survived. Patterns §10, §15, and §24 can remove these words while appearing to remove only shape.
    Treat any unsupported addition or lost claim as an error.
 4. Write the final version. State each point naturally instead of patching one flagged phrase at a time. If a sentence stays awkward, rewrite the paragraph around its main point. Apply the dash rule in §14.
 


### PR DESCRIPTION
This fix updates the fact integrity check to make sure important ranking and simultaneity claims are not accidentally removed during rewriting.

For example, words like “most”, “first”, “only”, "least" and “simultaneously” can carry important meaning even when they look like unnecessary wording.

I also updated the version to 2.11.3.
