### PR TITLE
Catch AI patterns that appear across a whole draft

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "humanizer",
   "description": "Rewrite AI-sounding text so it reads naturally without changing what it says.",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "author": {
     "name": "blader",
     "url": "https://github.com/blader"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Keep the skill portable. Do not write instructions that limit it to one or two a
 
 ## Key files
 
-- `SKILL.md` is the source of truth and the repo's only skill file. It contains portable YAML metadata, 35 numbered patterns, and their examples.
+- `SKILL.md` is the source of truth and the repo's only skill file. It contains portable YAML metadata, 36 numbered patterns, and their examples.
 - `README.md` explains installation, use, patterns, and version history.
 - `.claude-plugin/plugin.json` describes the Claude plugin and points its skill loader at the root `SKILL.md`.
 - `.claude-plugin/marketplace.json` lets users add this repo as a Claude marketplace.
@@ -20,7 +20,7 @@ Keep the skill portable. Do not write instructions that limit it to one or two a
 
 Keep `SKILL.md` and `README.md` in sync.
 
-- **Patterns:** The skill has 35 numbered patterns. If you add, remove, or renumber a pattern, update the README table, heading, validator, and every pattern reference.
+- **Patterns:** The skill has 36 numbered patterns. If you add, remove, or renumber a pattern, update the README table, heading, validator, and every pattern reference.
 - **Version:** Keep the same version in `SKILL.md` under `metadata.version`, the first README version entry, and `.claude-plugin/plugin.json`. Do not add a top-level `version` field to the skill.
 - **Compatibility:** Keep install and use instructions neutral across agents. Names such as Claude Code, OpenCode, and Codex are examples, not limits.
 - **History:** Add a short README version note for any behavior change or non-obvious fix.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Humanizer rewrites AI-sounding text so it reads like a person wrote it, without 
 
 ## How it works
 
-Humanizer uses 35 patterns from Wikipedia's ["Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. It makes a first pass without treating the original structure as fixed. Then it checks the draft against those patterns and the original claims before rewriting whatever still needs work.
+Humanizer uses 36 patterns from Wikipedia's ["Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. It makes a first pass without treating the original structure as fixed. Then it checks the full draft against those patterns and the original claims before rewriting whatever still needs work.
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 
@@ -52,7 +52,7 @@ Now humanize this text:
 
 Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate quirks.
 
-## The 35 patterns
+## The 36 patterns
 
 ### Content patterns
 
@@ -64,6 +64,7 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 | 4 | **Sales language** | "nestled within the breathtaking region" | "is a town in the Gonder region" |
 | 5 | **Vague sources** | "Experts believe it plays a crucial role" | Name a real source or remove the claim |
 | 6 | **Formulaic challenges and outlook** | "Despite challenges... continues to thrive" | Keep the facts and remove the sales pitch |
+| 36 | **Empty credibility signals** | "Research from Harvard confirms..." without the finding | State what the source adds or remove its name |
 
 ### Language and grammar patterns
 
@@ -71,8 +72,8 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 |---|---------|--------|-------|
 | 7 | **Overused AI words** | "Actually... additionally... gated on... quietly... testament... landscape... showcasing" | "also... needs... remain common" |
 | 8 | **Avoiding is and are** | "serves as... features... boasts" | "is... has" |
-| 9 | **Not X but Y and clipped endings** | "It's not just X, it's Y", "..., no guessing" | State the point directly |
-| 10 | **Forced groups of three** | "innovation, inspiration, and insights" | Use the number of items the meaning needs |
+| 9 | **Not X but Y and clipped endings** | "It's not just X, it's Y" across one or two sentences | State the point directly; keep useful distinctions |
+| 10 | **Forced groups of three** | Three list items or parallel examples added for cadence | Keep only examples that add distinct ideas |
 | 11 | **Changing names and repeated openings** | "protagonist... main character... hero" or "She noted... She noted... She filed..." | Use one name or merge the repeated sentences |
 | 12 | **False from X to Y ranges** | "from the Big Bang to dark matter" | List the topics directly |
 | 13 | **Passive voice and missing subjects** | "No configuration file needed" | Name the actor when that helps |
@@ -89,10 +90,10 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 | 19 | **Curly quotes** | `said “the project”` | `said "the project"` |
 | 26 | **Too many hyphenated word pairs** | “cross-functional, data-driven, client-facing” | Keep only the hyphens grammar needs |
 | 27 | **A fake deeper truth** | "At its core, what matters is..." | State the point directly |
-| 28 | **Announcing the next point** | "Let's dive in", or "one thing that bit me" | Start with the content |
+| 28 | **Announcing the next point** | "This is where X becomes useful" | Replace the bridge with the actual claim |
 | 29 | **A heading repeated below itself** | "## Performance" + "Speed matters." | Let the heading do the work |
 | 30 | **Writing about the old version** | "This function was added to replace..." | Describe what it does now |
-| 31 | **Forced punchlines and fragments** | "It had no preference. No prior. No nostalgia." | Use natural sentence lengths and specific claims |
+| 31 | **Forced punchlines and fragments** | Repeated fragments or one-line mini-conclusions | Merge lines that manufacture emphasis |
 | 32 | **Formulaic sayings** | "Symmetry is the language of trust" | State the specific claim |
 | 33 | **Fake-candid openings** | "Honestly? It depends..." | State the answer directly |
 | 34 | **Answering objections no one raised** | "This isn't mainly about prompt length..." | Remove the unsupported defense and keep any real claim |
@@ -154,12 +155,13 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 <details>
 <summary>Show release notes</summary>
 
-- **2.11.2** - Removed the plugin symlink and separate Claude Desktop package. Current Claude Code loads the root `SKILL.md` directly, so GitHub's source ZIP now works in Claude Desktop. No change to the 35 patterns.
-- **2.11.1** - Added a Claude Desktop-ready release package with one regular `humanizer/SKILL.md` file. GitHub's source archive still keeps the plugin symlink (fixes #224). No change to the 35 patterns.
-- **2.11.0** - Rewrote all repo guidance, descriptions, checks, and skill instructions in Plain Language. Kept all 35 patterns and their behavior.
+- **2.12.0** - Added empty credibility signals and expanded checks for generic bridges, split contrast formulas, repeated paragraph structures, and isolated proclamation lines. 36 patterns total.
+- **2.11.2** - Removed the plugin symlink and separate Claude Desktop package. Current Claude Code loads the root `SKILL.md` directly, so GitHub's source ZIP now works in Claude Desktop. No pattern changes.
+- **2.11.1** - Added a Claude Desktop-ready release package with one regular `humanizer/SKILL.md` file. GitHub's source archive still keeps the plugin symlink (fixes #224). No pattern changes.
+- **2.11.0** - Rewrote all repo guidance, descriptions, checks, and skill instructions in Plain Language without changing the pattern set.
 - **2.10.2** - Added the standard `skills/humanizer/` plugin path for Claude Desktop and older loaders. The path links to the root skill, so there is still one prompt (fixes #202).
 - **2.10.1** - Added figurative uses of `gate`, `gated`, and `gating` to §7. Kept real technical uses, such as feature gating and CI quality gates.
-- **2.10.0** - Added patterns #34 and #35 for old drafting ideas left in final text. Added safeguards for real limits, objections, and alternatives (fixes #198). Also improved §24 and the final rewrite step. 35 patterns total.
+- **2.10.0** - Added patterns #34 and #35 for old drafting ideas left in final text. Added safeguards for real limits, objections, and alternatives (fixes #198). Also improved §24 and the final rewrite step.
 - **2.9.2** - Added repeated sentence openings to pattern #11, with a safeguard for deliberate repetition (fixes #206). Expanded §28 to cover casual announcements. 33 patterns total.
 - **2.9.1** - Improved installation and package checks. Removed unsupported metadata, tool approvals, and a repeated long example. 33 patterns total.
 - **2.9.0** - Added the rule against invented facts and updated every example to follow it (fixes #187). Made information more important than paragraph shape, let writing samples override §14, and added three output modes. 33 patterns total.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 | 4 | **Sales language** | "nestled within the breathtaking region" | "is a town in the Gonder region" |
 | 5 | **Vague sources** | "Experts believe it plays a crucial role" | Name a real source or remove the claim |
 | 6 | **Formulaic challenges and outlook** | "Despite challenges... continues to thrive" | Keep the facts and remove the sales pitch |
-| 36 | **Empty credibility signals** | "Research from Harvard confirms..." without the finding | State what the source adds or remove its name |
+| 36 | **Empty credibility signals** | "The Stanford Encyclopedia of Philosophy places this tension..." mid-essay | State the claim; move the source to references |
 
 ### Language and grammar patterns
 
@@ -72,8 +72,8 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 |---|---------|--------|-------|
 | 7 | **Overused AI words** | "Actually... additionally... gated on... quietly... testament... landscape... showcasing" | "also... needs... remain common" |
 | 8 | **Avoiding is and are** | "serves as... features... boasts" | "is... has" |
-| 9 | **Not X but Y and clipped endings** | "It's not just X, it's Y" across one or two sentences | State the point directly; keep useful distinctions |
-| 10 | **Forced groups of three** | Three list items or parallel examples added for cadence | Keep only examples that add distinct ideas |
+| 9 | **Not X but Y and clipped endings** | "It's not just X, it's Y" across one or two sentences, or "..., no guessing" | State the point directly; keep useful distinctions |
+| 10 | **Forced groups of three** | Three parallel examples plus a lesson | Vary the structure; keep distinct ideas |
 | 11 | **Changing names and repeated openings** | "protagonist... main character... hero" or "She noted... She noted... She filed..." | Use one name or merge the repeated sentences |
 | 12 | **False from X to Y ranges** | "from the Big Bang to dark matter" | List the topics directly |
 | 13 | **Passive voice and missing subjects** | "No configuration file needed" | Name the actor when that helps |
@@ -90,10 +90,10 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 | 19 | **Curly quotes** | `said “the project”` | `said "the project"` |
 | 26 | **Too many hyphenated word pairs** | “cross-functional, data-driven, client-facing” | Keep only the hyphens grammar needs |
 | 27 | **A fake deeper truth** | "At its core, what matters is..." | State the point directly |
-| 28 | **Announcing the next point** | "This is where X becomes useful" | Replace the bridge with the actual claim |
+| 28 | **Announcing the next point** | "Let's dive in" / "This is where X becomes useful" | Replace the announcement with the claim |
 | 29 | **A heading repeated below itself** | "## Performance" + "Speed matters." | Let the heading do the work |
 | 30 | **Writing about the old version** | "This function was added to replace..." | Describe what it does now |
-| 31 | **Forced punchlines and fragments** | Repeated fragments or one-line mini-conclusions | Merge lines that manufacture emphasis |
+| 31 | **Forced punchlines and fragments** | Repeated fragments or the same mini-conclusion after several sections | Merge lines that manufacture emphasis |
 | 32 | **Formulaic sayings** | "Symmetry is the language of trust" | State the specific claim |
 | 33 | **Fake-candid openings** | "Honestly? It depends..." | State the answer directly |
 | 34 | **Answering objections no one raised** | "This isn't mainly about prompt length..." | Remove the unsupported defense and keep any real claim |
@@ -155,7 +155,7 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 <details>
 <summary>Show release notes</summary>
 
-- **2.12.0** - Added empty credibility signals and expanded checks for generic bridges, split contrast formulas, repeated paragraph structures, and isolated proclamation lines. 36 patterns total.
+- **2.12.0** - Added empty credibility signals: in essays, move inline prestige sources to a references section. Expanded whole-draft checks for empty bridges, split contrast formulas, three-example cadence, and mini-conclusions. Package checks now reject example Afters that fail those rules. 36 patterns total.
 - **2.11.2** - Removed the plugin symlink and separate Claude Desktop package. Current Claude Code loads the root `SKILL.md` directly, so GitHub's source ZIP now works in Claude Desktop. No pattern changes.
 - **2.11.1** - Added a Claude Desktop-ready release package with one regular `humanizer/SKILL.md` file. GitHub's source archive still keeps the plugin symlink (fixes #224). No pattern changes.
 - **2.11.0** - Rewrote all repo guidance, descriptions, checks, and skill instructions in Plain Language without changing the pattern set.

--- a/SKILL.md
+++ b/SKILL.md
@@ -155,7 +155,7 @@ State the useful claim directly. Keep a contrast when both sides add information
 **Before (paragraph structure):**
 > A career can look promising and fail. A relationship can feel important and end. A skill can take years and remain useless. These decisions rarely explain themselves.
 **After:**
-> A promising career can stall, a relationship can matter even if it ends, and a hard-won skill may never prove useful. Decisions like these may take years to make sense.
+> A career can look promising and fail. So can a relationship that felt important and ended, or a skill that took years and remained useless. These decisions rarely explain themselves.
 
 Check that every example adds a distinct idea. Merge examples, develop the strongest one, or vary the structure when they do not. Keep three real items when the meaning needs three.
 
@@ -322,10 +322,14 @@ Before returning the rewrite, search for `—` and `–`. Remove each one unless
 
 ### 28. Announcing the next point
 
-**Phrases to watch:** Let's dive in, here's what you need to know, this is where X becomes useful, that difference changes everything, the same applies to X, there is also the question of X
-**Problem:** AI writing often announces a clarification, connection, limit, or new section instead of stating it. Delete an empty bridge or replace it with the claim that follows. Keep a transition when it explains a real relationship between paragraphs.
+**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado, heads up, quick note, before I forget, this is where X becomes useful, that difference changes everything, the same applies to X, there is also the question of X
+**Problem:** AI writing often announces the next point instead of stating it. Delete an empty bridge or replace it with the claim that follows. A casual phrase such as "one thing that bit me" can have the same problem. Keep a transition when it explains a real relationship between paragraphs.
 **Before:**
-> Albert Camus was describing something more specific. Human beings want the world to make sense.
+> Let's dive into how caching works in Next.js. Here's what you need to know.
+**After:**
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+**Before (empty bridge):**
+> This is where Camus becomes useful. Human beings want the world to make sense.
 **After:**
 > Camus described our desire for the world to make sense.
 **Before (casual register):**
@@ -356,19 +360,23 @@ Before returning the rewrite, search for `—` and `–`. Remove each one unless
 > This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
 
 ### 31. Forced punchlines and dramatic fragments
-**Problem:** AI writing often turns each sentence into a dramatic closing line. It may also isolate one short sentence in its own paragraph to repeat the surrounding point or sound quotable. One short paragraph can be natural; flag it when it interrupts explanatory prose or adds no new meaning.
+**Problem:** AI writing often turns each sentence into a dramatic closing line. It may also isolate a short sentence to repeat the surrounding point. One short paragraph can be natural; flag a mini-conclusion when it repeats nearby prose or when several sections end with the same kind of line.
 **Before:**
 > Then AlphaEvolve arrived. It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone.
 **After:**
 > AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
-**Before (isolated proclamation):**
-> We did not know which option was correct.
+**Before (mini-conclusions):**
+> Caching cuts repeat work.
 >
-> We still had to choose.
+> That is the real win.
+>
+> Retries hide brief outages.
+>
+> That is the real win.
 **After:**
-> We had to choose without knowing which option was correct.
-
-Merge a staged line into the surrounding paragraph or rewrite the paragraph around its claim. Check the whole draft for repeated mini-conclusions, especially when nearly every section ends with one.
+> Caching cuts repeat work.
+>
+> Retries hide brief outages.
 
 ### 32. Formulaic sayings
 
@@ -412,14 +420,17 @@ One rejected option may be valid. Several short, unrelated rejections are a stro
 
 ### 36. Empty credibility signals
 
-**Signs to watch:** A citation, publication, university, or institution is named without explaining what it contributes.
-**Problem:** A real source can still be used as a badge of authority. Keep it when it supports a disputed fact, provides a useful finding, adds needed context, or is required by the format. If the source matters, say what it found or argued. If only its prestige remains, remove it.
+**Signs to watch:** A citation, publication, university, or institution named in the sentence as a badge of authority.
+**Problem:** AI writing drops a prestige name into the prose. In essays and blog posts, that name stops the reader even when the source is real.
 **Before:**
 > The Stanford Encyclopedia of Philosophy places this tension at the centre of Camus's work.
 **After:**
-> The Stanford Encyclopedia of Philosophy describes this tension as central to Camus's work.
+> This tension is central to Camus's work.
+>
+> ## References
+> Stanford Encyclopedia of Philosophy
 
-Treat an attributed interpretation as part of the claim. Do not turn a source's view into an unqualified statement. Do not add a finding or claim that is absent from the source text. In essays and blog posts, optional reading may move to a short references section when the input already contains the links. Do not create links or a references section from nothing. In file mode, preserve link targets.
+In essays and blog posts, the sentence must state the claim, and the source must move to a short references section. A source in references is kept, not removed. Do not invent a URL, title, or finding. Keep existing link targets. Keep the source in the sentence when the format requires a citation, or when the reader needs it there to judge a disputed fact.
 
 ## Check for false positives
 
@@ -435,7 +446,7 @@ A person may use some of these patterns. Do not treat any item below as proof by
 - **Common transition words in isolation.** *Additionally*, *moreover*, *consequently* are AI-coded only when piled up. One *however* is not a tell.
 - **Curly quotes alone.** macOS, Word, Google Docs, and most CMSes auto-curl by default. Curly quotes only count when stacked with other tells.
 - **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
-- **One short sentence for emphasis.** Flag it only when it repeats nearby prose or interrupts it without adding meaning. Several dramatic fragments in a row are a stronger signal.
+- **One short sentence for emphasis.** Flag a mini-conclusion only when it repeats nearby prose or interrupts it without adding meaning. Several dramatic fragments in a row are a stronger signal.
 - **Deliberate repeated openings.** Writers may repeat an opening to build rhythm or pressure, as in "She came. She saw. She conquered." Change it only when the repetition adds nothing.
 - **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
 - **Useful limits and disclaimers.** Keep scope statements, legal and safety notices, real corrections, named objections, replies, and FAQ answers.
@@ -476,7 +487,7 @@ These details often carry the writer's voice. Keep them unless they hurt the mea
    - **"What still sounds AI-generated?"**
    - **"Did the rewrite add or remove any fact, name, number, date, quote, citation, ranking, or other claim?"**
    Treat any unsupported addition or lost claim as an error.
-4. Audit the whole draft. Check whether each transition adds information, paragraphs repeat the same setup-example-lesson shape, standalone lines do real work, and each named source adds a finding or needed context. Confirm that every original claim remains and no new fact was added.
+4. Audit the whole draft for empty bridges, repeated paragraph shapes, mini-conclusions, and prestige names that belong in references. Confirm that every original claim remains and no new fact was added.
 5. Write the final version. State each point naturally instead of patching one flagged phrase at a time. If a sentence stays awkward, rewrite the paragraph around its main point. Apply the dash rule in §14.
 
 Return the result required by [How to return the result](#how-to-return-the-result).

--- a/SKILL.md
+++ b/SKILL.md
@@ -155,7 +155,7 @@ State the useful claim directly. Keep a contrast when both sides add information
 **Before (paragraph structure):**
 > A career can look promising and fail. A relationship can feel important and end. A skill can take years and remain useless. These decisions rarely explain themselves.
 **After:**
-> A promising career can stall, and a relationship can matter even if it ends. Decisions like these may take years to make sense.
+> A promising career can stall, a relationship can matter even if it ends, and a hard-won skill may never prove useful. Decisions like these may take years to make sense.
 
 Check that every example adds a distinct idea. Merge examples, develop the strongest one, or vary the structure when they do not. Keep three real items when the meaning needs three.
 
@@ -417,9 +417,9 @@ One rejected option may be valid. Several short, unrelated rejections are a stro
 **Before:**
 > The Stanford Encyclopedia of Philosophy places this tension at the centre of Camus's work.
 **After:**
-> This tension is central to Camus's work.
+> The Stanford Encyclopedia of Philosophy describes this tension as central to Camus's work.
 
-Do not add a finding or claim that is absent from the source text. In essays and blog posts, optional reading may move to a short references section when the input already contains the links. Do not create links or a references section from nothing. In file mode, preserve link targets.
+Treat an attributed interpretation as part of the claim. Do not turn a source's view into an unqualified statement. Do not add a finding or claim that is absent from the source text. In essays and blog posts, optional reading may move to a short references section when the input already contains the links. Do not create links or a references section from nothing. In file mode, preserve link targets.
 
 ## Check for false positives
 
@@ -435,7 +435,7 @@ A person may use some of these patterns. Do not treat any item below as proof by
 - **Common transition words in isolation.** *Additionally*, *moreover*, *consequently* are AI-coded only when piled up. One *however* is not a tell.
 - **Curly quotes alone.** macOS, Word, Google Docs, and most CMSes auto-curl by default. Curly quotes only count when stacked with other tells.
 - **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
-- **One short sentence for emphasis.** Flag dramatic fragments only when several appear in a row.
+- **One short sentence for emphasis.** Flag it only when it repeats nearby prose or interrupts it without adding meaning. Several dramatic fragments in a row are a stronger signal.
 - **Deliberate repeated openings.** Writers may repeat an opening to build rhythm or pressure, as in "She came. She saw. She conquered." Change it only when the repetition adds nothing.
 - **"Honestly" or "look" mid-sentence.** These are ordinary in casual writing. The tell is the standalone theatrical opener, not the word itself.
 - **Useful limits and disclaimers.** Keep scope statements, legal and safety notices, real corrections, named objections, replies, and FAQ answers.

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: |
   voice, filler, or chatbot artifacts. Based on Wikipedia's "Signs of AI writing."
 license: MIT
 metadata:
-  version: "2.11.2"
+  version: "2.12.0"
 ---
 
 # Humanizer: remove AI writing patterns
@@ -128,7 +128,7 @@ Add details such as dates or public actions only when they come from the source 
 > Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
 
 ### 9. Not X but Y and clipped negative endings
-**Problem:** AI writing overuses forms such as "Not only...but..." and "It's not just X, it's Y."
+**Problem:** AI writing overuses forms such as "Not only...but..." and "It's not just X, it's Y." The same formula may be split across nearby sentences or paragraphs: "This does not mean X. It means Y," or "X is not Y. It is Z."
 
 It also adds clipped endings such as "no guessing" instead of writing a clear clause.
 **Before:**
@@ -139,13 +139,25 @@ It also adds clipped endings such as "no guessing" instead of writing a clear cl
 > The options come from the selected item, no guessing.
 **After:**
 > The options come from the selected item without forcing the user to guess.
+**Before (split contrast):**
+> This does not mean every choice is equal. It means there is no external system that confirms which choice is right.
+**After:**
+> No external system confirms which choice is right, although the choices still have different consequences.
+
+State the useful claim directly. Keep a contrast when both sides add information or correct a real misunderstanding.
 
 ### 10. Forced groups of three
-**Problem:** AI writing often forces ideas into groups of three to sound complete.
+**Problem:** AI writing often forces ideas into groups of three to sound complete. This can span a sentence, three parallel examples, or three short facts followed by a lesson.
 **Before:**
 > The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
 **After:**
 > The event includes talks and panels. There's also time for informal networking between sessions.
+**Before (paragraph structure):**
+> A career can look promising and fail. A relationship can feel important and end. A skill can take years and remain useless. These decisions rarely explain themselves.
+**After:**
+> A promising career can stall, and a relationship can matter even if it ends. Decisions like these may take years to make sense.
+
+Check that every example adds a distinct idea. Merge examples, develop the strongest one, or vary the structure when they do not. Keep three real items when the meaning needs three.
 
 ### 11. Changing names and repeating sentence openings
 **Problem:** AI writing handles repetition by rule instead of by ear. It may keep renaming the same person or thing. It may also start several sentences with the same subject, often *she* or *he*.
@@ -310,12 +322,12 @@ Before returning the rewrite, search for `—` and `–`. Remove each one unless
 
 ### 28. Announcing the next point
 
-**Phrases to watch:** Let's dive in, let's explore, let's break this down, here's what you need to know, now let's look at, without further ado, heads up, quick note, before I forget
-**Problem:** AI writing often announces the next point instead of stating it. A casual phrase such as "one thing that bit me" can have the same problem. Remove the announcement, not just its formal tone.
+**Phrases to watch:** Let's dive in, here's what you need to know, this is where X becomes useful, that difference changes everything, the same applies to X, there is also the question of X
+**Problem:** AI writing often announces a clarification, connection, limit, or new section instead of stating it. Delete an empty bridge or replace it with the claim that follows. Keep a transition when it explains a real relationship between paragraphs.
 **Before:**
-> Let's dive into how caching works in Next.js. Here's what you need to know.
+> Albert Camus was describing something more specific. Human beings want the world to make sense.
 **After:**
-> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
+> Camus described our desire for the world to make sense.
 **Before (casual register):**
 > One thing that bit me hard, so pay attention to this part: the webpack dev server doesn't send the CORS header by default.
 **After:**
@@ -344,11 +356,19 @@ Before returning the rewrite, search for `—` and `–`. Remove each one unless
 > This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
 
 ### 31. Forced punchlines and dramatic fragments
-**Problem:** AI writing often turns each sentence into a dramatic closing line. One short sentence can add emphasis. A row of short fragments usually feels forced.
+**Problem:** AI writing often turns each sentence into a dramatic closing line. It may also isolate one short sentence in its own paragraph to repeat the surrounding point or sound quotable. One short paragraph can be natural; flag it when it interrupts explanatory prose or adds no new meaning.
 **Before:**
 > Then AlphaEvolve arrived. It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone.
 **After:**
 > AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
+**Before (isolated proclamation):**
+> We did not know which option was correct.
+>
+> We still had to choose.
+**After:**
+> We had to choose without knowing which option was correct.
+
+Merge a staged line into the surrounding paragraph or rewrite the paragraph around its claim. Check the whole draft for repeated mini-conclusions, especially when nearly every section ends with one.
 
 ### 32. Formulaic sayings
 
@@ -389,6 +409,17 @@ Remove only the unsupported defense. If it contains a real claim, state that cla
 > Session tokens are rotated every 24 hours, in place, and clients refresh transparently.
 
 One rejected option may be valid. Several short, unrelated rejections are a stronger sign. Ask what new information each sentence adds. If it only records an earlier edit, rewrite the paragraph around its main point.
+
+### 36. Empty credibility signals
+
+**Signs to watch:** A citation, publication, university, or institution is named without explaining what it contributes.
+**Problem:** A real source can still be used as a badge of authority. Keep it when it supports a disputed fact, provides a useful finding, adds needed context, or is required by the format. If the source matters, say what it found or argued. If only its prestige remains, remove it.
+**Before:**
+> The Stanford Encyclopedia of Philosophy places this tension at the centre of Camus's work.
+**After:**
+> This tension is central to Camus's work.
+
+Do not add a finding or claim that is absent from the source text. In essays and blog posts, optional reading may move to a short references section when the input already contains the links. Do not create links or a references section from nothing. In file mode, preserve link targets.
 
 ## Check for false positives
 
@@ -445,7 +476,8 @@ These details often carry the writer's voice. Keep them unless they hurt the mea
    - **"What still sounds AI-generated?"**
    - **"Did the rewrite add or remove any fact, name, number, date, quote, citation, ranking, or other claim?"**
    Treat any unsupported addition or lost claim as an error.
-4. Write the final version. State each point naturally instead of patching one flagged phrase at a time. If a sentence stays awkward, rewrite the paragraph around its main point. Apply the dash rule in §14.
+4. Audit the whole draft. Check whether each transition adds information, paragraphs repeat the same setup-example-lesson shape, standalone lines do real work, and each named source adds a finding or needed context. Confirm that every original claim remains and no new fact was added.
+5. Write the final version. State each point naturally instead of patching one flagged phrase at a time. If a sentence stays awkward, rewrite the paragraph around its main point. Apply the dash rule in §14.
 
 Return the result required by [How to return the result](#how-to-return-the-result).
 

--- a/scripts/validate-package.py
+++ b/scripts/validate-package.py
@@ -73,14 +73,14 @@ pattern_numbers = [
     int(number)
     for number in re.findall(r"(?m)^### ([0-9]+)\. ", SKILL)
 ]
-if pattern_numbers != list(range(1, 36)):
-    raise SystemExit(f"Number SKILL.md patterns from 1 through 35: {pattern_numbers}")
+if pattern_numbers != list(range(1, 37)):
+    raise SystemExit(f"Number SKILL.md patterns from 1 through 36: {pattern_numbers}")
 
 readme_numbers = {
     int(number) for number in re.findall(r"(?m)^\| ([0-9]+) \|", README)
 }
-if readme_numbers != set(range(1, 36)):
-    raise SystemExit("List patterns 1 through 35 in the README table")
+if readme_numbers != set(range(1, 37)):
+    raise SystemExit("List patterns 1 through 36 in the README table")
 
 if len(SKILL.splitlines()) > 500:
     raise SystemExit("Keep SKILL.md at 500 lines or fewer")

--- a/scripts/validate-package.py
+++ b/scripts/validate-package.py
@@ -82,6 +82,105 @@ readme_numbers = {
 if readme_numbers != set(range(1, 37)):
     raise SystemExit("List patterns 1 through 36 in the README table")
 
+
+def section_between(text: str, start: str, end: str) -> str:
+    start_at = text.find(start)
+    end_at = text.find(end, start_at + len(start) if start_at != -1 else 0)
+    if start_at == -1 or end_at == -1:
+        raise SystemExit(f"Keep a {start} section in SKILL.md")
+    return text[start_at:end_at]
+
+
+def require_in(label: str, text: str, *snippets: str) -> None:
+    for snippet in snippets:
+        if snippet not in text:
+            raise SystemExit(f"{label} must include {snippet!r}")
+
+
+def quoted_after(section: str, before_marker: str) -> str:
+    if before_marker not in section:
+        raise SystemExit(f"Keep {before_marker} in SKILL.md")
+    rest = section.split(before_marker, 1)[1]
+    if "**After:**" not in rest:
+        raise SystemExit(f"{before_marker} must include an After example")
+    quoted: list[str] = []
+    for line in rest.split("**After:**", 1)[1].splitlines():
+        if line.startswith(">"):
+            quoted.append(line[1:].lstrip())
+            continue
+        if quoted:
+            break
+    if not quoted:
+        raise SystemExit(f"{before_marker} After must include a quoted example")
+    return "\n".join(quoted)
+
+
+def readme_row(number: int) -> str:
+    prefix = f"| {number} |"
+    for line in README.splitlines():
+        if line.startswith(prefix):
+            return line
+    raise SystemExit(f"List pattern {number} in the README table")
+
+
+section_10 = section_between(SKILL, "### 10. Forced groups of three", "### 11.")
+after_10 = quoted_after(section_10, "**Before (paragraph structure):**")
+require_in(
+    "§10 After",
+    after_10.lower(),
+    "career",
+    "relationship",
+    "end",
+    "skill",
+    "these decisions rarely explain themselves.",
+)
+if "may take years to make sense" in after_10:
+    raise SystemExit("§10 After must not replace the original lesson")
+
+section_28 = section_between(SKILL, "### 28. Announcing the next point", "### 29.")
+require_in(
+    "§28",
+    section_28,
+    "Let's dive in",
+    "this is where X becomes useful",
+    "one thing that bit me",
+    "Let's dive into how caching works in Next.js",
+    "This is where Camus becomes useful",
+)
+
+section_31 = section_between(SKILL, "### 31. Forced punchlines and dramatic fragments", "### 32.")
+if section_31.count("That is the real win.") < 2:
+    raise SystemExit("§31 Before must repeat the mini-conclusion")
+after_31 = quoted_after(section_31, "**Before (mini-conclusions):**")
+require_in("§31 After", after_31, "Caching cuts repeat work", "Retries hide brief outages")
+if "That is the real win." in after_31:
+    raise SystemExit("§31 After must drop the repeated mini-conclusion")
+
+section_36 = section_between(SKILL, "### 36. Empty credibility signals", "## Check for false positives")
+after_36 = quoted_after(section_36, "**Before:**")
+if "## References" not in after_36:
+    raise SystemExit("§36 After must include a references section")
+prose_36, references_36 = after_36.split("## References", 1)
+if "Stanford Encyclopedia" in prose_36:
+    raise SystemExit("§36 After must move the source out of the sentence")
+require_in("§36 After", prose_36, "This tension is central to Camus's work.")
+require_in("§36 After", references_36, "Stanford Encyclopedia of Philosophy")
+
+row_9 = readme_row(9)
+if "no guessing" not in row_9:
+    raise SystemExit("README #9 must keep the clipped-ending example")
+row_10 = readme_row(10)
+if "lesson" not in row_10.lower():
+    raise SystemExit("README #10 must mention the three-example lesson")
+row_28 = readme_row(28)
+require_in("README #28", row_28, "Let's dive in", "This is where X becomes useful")
+row_31 = readme_row(31)
+if "mini-conclusion" not in row_31.lower():
+    raise SystemExit("README #31 must mention mini-conclusions")
+row_36 = readme_row(36)
+if "references" not in row_36.lower():
+    raise SystemExit("README #36 must move the source to references")
+
 if len(SKILL.splitlines()) > 500:
     raise SystemExit("Keep SKILL.md at 500 lines or fewer")
 


### PR DESCRIPTION
## What this improves

Humanizer now catches several habits that only become obvious across sentences or paragraphs: split correction formulas, three-example cadence, empty bridge lines, and repeated mini-conclusions. It also catches source names used only to borrow credibility instead of telling the reader what the source adds.

The second pass now checks the shape of the full draft, so it can rewrite repeated structures instead of patching one phrase at a time.


## False-positive safeguards

The new guidance keeps real distinctions, meaningful transitions, necessary examples, deliberate short paragraphs, and citations that support a fact or useful finding. It also keeps the existing rule against adding claims or sources that were not in the input.

## Validation

- `python3 scripts/validate-package.py`
- `npx skills add . --list`
- `npx -y @anthropic-ai/claude-code plugin validate .`

Note: In essays, a prestige source in the sentence is an empty credibility signal even when the source is real. State the claim; move the source to references. validate-package.py now rejects example Afters that miss §10 / §28 / §31 / §36.