### PR TITLE
ci: add PR validators

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Check package files
         run: python3 scripts/validate-package.py
       - name: Check skill discovery
+        # Pin skill validator version for reproducibility.
+        # Update by checking https://registry.npmjs.org/skills for latest versions.
         run: npx --yes skills@1.5.23 add . --list
       - name: Check Claude marketplace
+        # Pin @anthropic-ai/claude-code version for reproducible validation.
+        # Update by checking https://www.npmjs.com/package/@anthropic-ai/claude-code for latest versions.
         run: npx --yes @anthropic-ai/claude-code@2.1.263 plugin validate .

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,15 +1,14 @@
-name: Check package
+name: PR validators
 
 on:
-  pull_request:
   push:
-    branches: [main]
+  pull_request:
 
 permissions:
   contents: read
 
 jobs:
-  check:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,8 +21,6 @@ jobs:
       - name: Check package files
         run: python3 scripts/validate-package.py
       - name: Check skill discovery
-        run: npx --yes skills@1.5.20 add . --list
+        run: npx --yes skills@1.5.23 add . --list
       - name: Check Claude marketplace
-        run: |
-          npm install --global @anthropic-ai/claude-code
-          claude plugin validate .
+        run: npx --yes @anthropic-ai/claude-code@2.1.263 plugin validate .


### PR DESCRIPTION
## Summary

- run package validation on every branch push and pull request
- validate skill discovery and the Claude marketplace
- pin both npm validators for reproducible CI runs

## Validation

- `python3 scripts/validate-package.py`
- `npx --yes skills@1.5.23 add . --list`
- `npx --yes @anthropic-ai/claude-code@2.1.263 plugin validate .`