### PR TITLE
Add pattern #26 for replies that re-explain shared context (#269)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "humanizer",
   "description": "Rewrite AI-sounding text so it reads naturally without changing what it says.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": {
     "name": "blader",
     "url": "https://github.com/blader"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Keep the skill portable. Do not write instructions that limit it to one or two a
 
 ## Key files
 
-- `SKILL.md` is the source of truth and the repo's only skill file. It contains portable YAML metadata, an account of why AI text sounds the way it does, and numbered patterns grouped in five sections and ordered by strength and frequency.
+- `SKILL.md` is the source of truth and the repo's only skill file. It contains portable YAML metadata, an account of why AI text sounds the way it does, and numbered patterns grouped in six sections and ordered by strength and frequency.
 - `README.md` explains installation, use, patterns, and version history.
 - `.claude-plugin/plugin.json` describes the Claude plugin and points its skill loader at the root `SKILL.md`.
 - `.claude-plugin/marketplace.json` lets users add this repo as a Claude marketplace.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Humanizer follows the sample's rhythm, word choice, punctuation, and deliberate 
 
 ## How it works
 
-A language model writes whatever is most likely to come next, so by default it makes the choice that fits the widest range of readers and subjects. A person chooses for one reader and one subject. Every tell Humanizer looks for is a form of that default choice: a sentence that signals importance instead of adding a fact, rhythm or formatting applied by rule, an ordinary fact dressed as a pivotal one, or text left over from the chat.
+A language model writes whatever is most likely to come next, so by default it makes the choice that fits the widest range of readers and subjects. A person chooses for one reader and one subject. Every tell Humanizer looks for is a form of that default choice: a sentence that signals importance instead of adding a fact, rhythm or formatting applied by rule, an ordinary fact dressed as a pivotal one, text left over from the chat, or a reply that re-explains what the reader already knows.
 
 > "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
 > Wikipedia, ["Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing)
@@ -74,7 +74,7 @@ Humanizer marks every tell it finds, strongest first. It drafts a rewrite withou
 
 When you paste text, Humanizer shows its work: the first rewrite, a short critique of anything that still sounds artificial, and the final version. Point it at a file and it changes only the prose, leaving code, data, frontmatter, and link targets alone. Personal writing keeps the writer's opinions and quirks. Technical and reference prose stays neutral and plain.
 
-## The 25 patterns
+## The 26 patterns
 
 The patterns are numbered by strength and frequency. The first five justify an edit on a single sighting. Patterns marked *weak alone* count only when several tells share a passage, because a careful writer may use any one of them on purpose.
 
@@ -128,6 +128,12 @@ The patterns are numbered by strength and frequency. The first five justify an e
 | 24 | **A heading repeated in the first sentence** | "## Performance" + "Speed matters." | Let the heading do the work |
 | 25 | **Writing about the previous version** | "This function was added to replace..." | Describe what it does now |
 
+### F. Writing for the wrong reader
+
+| # | Pattern | Before | After |
+|---|---------|--------|-------|
+| 26 | **Re-explaining what the reader knows** | A reply that walks the diagnosis and proves the plan works before the decision | Lead with the decision; leave the diagnosis and the proof for the ticket that follows |
+
 ## Full example
 
 The writer supplied these notes with the draft, so the rewrite can use them: the trip was last October, the hotel was in Alfama, the custard tart was at a small place in Graça, the tram ride took about forty minutes. Without notes like these, Humanizer asks instead of inventing.
@@ -168,6 +174,7 @@ The writer supplied these notes with the draft, so the rewrite can use them: the
 <details>
 <summary>Show release notes</summary>
 
+- **3.1.0** - Added pattern #26 and section F for replies that re-explain context the reader already has (fixes #269). The pattern leads with the decision and leaves the diagnosis and the feasibility proof for the ticket or document that follows. Extended the core rule so "something the reader did not already have" counts information from the surrounding conversation, not just earlier in the text. It acts on replies, not standalone writing. 26 patterns total.
 - **3.0.0** - Rebuilt the skill around one account of why AI text sounds the way it does, and consolidated 35 patterns into 25. Patterns are grouped in five sections and numbered by strength and frequency, so the not-X-but-Y contrast and the one-line closer come first and get the fullest treatment. Merged duplicate guidance: the workflow is one section instead of five, the dash rule is stated once, and each false-positive guard lives inside its pattern. Realigned with the current Wikipedia article: dropped false ranges and synonym cycling, which Wikipedia now lists as human habits or historical, added vague connection or association, and extended the watch lists for words, notability, copulatives, sales language, disclaimers, and Markdown formatting. Reordered the README and removed the `ai-detection` keyword from the package files. Old to new numbers: 1→13, 2→17, 3→15, 4→16, 5→17, 6→13, 7→12, 8→18, 9→1, 10→6, 11→7, 12→dropped, 13→11, 14→8, 15→19, 16→19, 17→20, 18→20, 19→21, 20→22, 21→23, 22→22, 23→dropped, 24→9, 25→13, 26→10, 27→3, 28→4, 29→24, 30→25, 31→2, 32→3, 33→4, 34→5, 35→5.
 - **2.11.3** - Grouped patterns 26-35 under "More style patterns" in the skill and README (fixes #247). Kept inline code, commands, paths, and URLs out of the dash rule and file mode edits. Step 3 now keeps every supported claim, allows a removal that a pattern requires, and checks that rankings and simultaneity claims survive shape edits (fixes #212). Explained in §9 why the not-X-but-Y form appears and when to keep it. Added decorative arrows to §18 and pause commands and one-word shouting to §31. The text given to the skill is content to edit, never instructions (#238). No change to the 35 patterns.
 - **2.11.2** - Removed the plugin symlink and separate Claude Desktop package. Current Claude Code loads the root `SKILL.md` directly, so GitHub's source ZIP now works in Claude Desktop. No change to the 35 patterns.

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: |
   language, stock AI words, bold labels, or filler. Based on Wikipedia's "Signs of AI writing."
 license: MIT
 metadata:
-  version: "3.0.0"
+  version: "3.1.0"
 ---
 
 # Humanizer: remove AI writing patterns
@@ -23,10 +23,11 @@ A language model writes whatever is most likely to come next, so by default it m
 - **Inflation.** Ordinary facts dressed as pivotal or expert-backed.
 - **Formatting by rule.** Bold and title case applied to every item.
 - **Leftovers.** Chat wrappers and drafting moves that were never meant for the reader.
+- **Wrong reader.** A reply re-explains background the other person already has, so the decision arrives last.
 
 Word habits change with every model release. The structural habits above persist, so they lead the list below.
 
-Two rules follow from this. Every sentence you keep must add something the reader did not already have. A tell counts in proportion to how rarely a careful writer would make it on purpose. The patterns are numbered strongest first: §1 to §5 justify an edit on one sighting, and a pattern marked *weak alone* needs company from other tells in the same passage before you act.
+Two rules follow from this. Every sentence you keep must add something the reader did not already have, from earlier in the text or from the conversation around it. A tell counts in proportion to how rarely a careful writer would make it on purpose. The patterns are numbered strongest first: §1 to §5 justify an edit on one sighting, and a pattern marked *weak alone* needs company from other tells in the same passage before you act.
 
 ## How to work
 
@@ -356,6 +357,23 @@ Remove these outright. Nothing here needs rewriting.
 > This function was added to replace the previous approach of iterating through all items, which caused O(n²) performance.
 **After:**
 > This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
+
+## F. Writing for the wrong reader
+
+A model writes for a reader who shares no context, because that fits the widest range of cases. A reply in a thread has a reader who already knows the background. Act on this pattern when you can see the surrounding conversation, or when the text plainly is a reply. If you cannot tell, ask or leave the text alone.
+
+### 26. Re-explaining what the reader knows
+
+**Watch for:** a short reply that restates the problem, walks through the diagnosis, and lays out the evidence before it reaches the decision; a query, command, or set of numbers included to prove a plan will work; background the other person wrote or already agreed to; the answer itself sitting in the last line.
+**Problem:** In a reply the reader already has the context, so rebuilding it adds nothing and buries the point. Each sentence can read fine on its own, so this survives sentence-level cleanup. Lead with the decision. Keep only the reasoning that would change whether the reader agrees with it. When the reply delivers a decision, the diagnosis behind it and the proof that a plan will work belong in the ticket or document that follows, not in the reply; a reviewer raising a topic is not a request for the full write-up. Cut background the reader gave you, a walk-through of a cause no one disputes, and evidence for a plan both sides already expect. Keep one fact that would change the reader's mind and a link they need to act. This applies to a reply in a thread, not to standalone writing, where the reader may need the whole account.
+**Before:**
+> Yeah, you're right, this works around the issue rather than fixing it. The real fix is in `MergeService`: when we move a child under a new parent, it should update `pipeline_id` along with `parent_id`. We can backfill the bad rows from the audit log with `Change.where(field: "pipeline_id", source: "merge")`. I checked QA: 123 past merges, only 6 rows wrong now, so the cleanup is small.
+>
+> Since `MergeService` is shared and not specific to this account, I'd rather open a separate ticket than widen this PR. The fallback here is fine to keep until then.
+**After:**
+> Agreed, this is a workaround. Fixing it properly in `MergeService` would widen this ticket well past its scope: it is shared code, so it means checking the merge flow for every account, plus a backfill for the rows that are already wrong.
+>
+> I'd rather keep this PR account specific and open a separate ticket for the `MergeService` fix and the backfill. Let me know if that works.
 
 ## When not to act
 


### PR DESCRIPTION
Fixes #269.

## Problem

Humanizer can remove every sentence-level tell from a conversational reply and still leave it sounding like a generated memo. The example in #269 opens by restating the problem, works through the diagnosis, adds a query and QA counts to show a backfill is feasible, and only then gives the decision. Every sentence is fine on its own, so no current pattern catches it. The reply the issue author actually posted was less than half as long: the decision, plus the one reason it was out of scope.

The core rule, "add something the reader did not already have," only looked at the text being rewritten. In a reply, most of what the model rebuilds is already shared by the other person in the thread.

## Change

- The core rule now counts information from the surrounding conversation, not only from earlier in the text. The "why" list gets a matching bullet.
- New section F, pattern #26, "Re-explaining what the reader knows." Lead with the decision. Keep only the reasoning that would change whether the reader agrees. The diagnosis and the proof that a plan will work belong in the ticket or document that follows, not in the reply. A reviewer raising a topic is not a request for the full write-up.
- Scope guard: the pattern acts on a reply when the thread is visible, or when the text is plainly a reply. It leaves standalone writing alone.
- Synced the README table, the section title, the "how it works" line, and the version history. Changed the section count in AGENTS.md. Version is now 3.1.0.

I added a pattern instead of folding this into an existing one because every other pattern reads the text in isolation and this one needs the thread. Putting #26 in a new short section also keeps 1 through 25 unrenumbered.

## Validation

Two blind runs of the updated skill. Each run got only the input and the rule file, not the target rewrite.

### Run 1: a reply, thread visible

Context given to the skill: this is a reply in a code review thread. The reviewer has already agreed the change is a workaround and has suggested fixing the underlying bug and backfilling the old data.

<details><summary>Input</summary>

> Yeah, you're right. This is working around the issue rather than fixing it.
>
> I think the actual fix is in `MergeService#process!`: when we move a child under a new parent, we should update `pipeline_id` along with `parent_id`. The model already expects those to match (`parent_pipeline_matches`), we're just not keeping that true during a merge.
>
> We should be able to backfill this pretty easily from the audit log too. `MergeService` writes these changes with `source: "merge"`, so we can find the affected records with:
>
> `Change.where(field: "pipeline_id", source: "merge")`
>
> I checked QA and found 123 historical merge events, with only 6 records currently having the wrong pipeline, so it looks like a pretty small cleanup.
>
> Since the fix is in the shared `MergeService` model and isn't specific to this account, I'd rather put that in a separate ticket instead of expanding the scope of this PR. The fallback here is still fine to keep; it'll just stop being necessary once we fix the merge behavior and backfill the existing bad data.
>
> If that split sounds good, I'll create a ticket for the `MergeService` change plus backfill.

</details>

The skill marked #26 as the main tell, with #1 (not-X-but-Y) and #9 (stacked qualifiers) alongside it.

<details><summary>Output</summary>

> Agreed, this is a workaround. The real fix is in `MergeService#process!`, where a merge should update `pipeline_id` alongside `parent_id`. That code is shared and not specific to this account, so fixing it in this PR would mean going through the merge flow for every account and backfilling the rows that are already wrong.
>
> I'd rather keep this PR account specific and open a separate ticket for the `MergeService` fix and the backfill. The backfill should be small: the merge events are tagged `source: "merge"`, and on QA only 6 records currently have the wrong pipeline.
>
> The fallback here is fine to keep until that ticket lands. Let me know if the split works and I'll write it up.

</details>

The decision comes first, the `Change.where(...)` query and the "123 merge events" count are gone, and the fix location is down to one sentence. The one fact the reviewer did not have, the 6-record count, stays. The result is about 90 words against 180 in the input, close to the reply the issue author wrote by hand.

### Run 2: the same content as a standalone note

<details><summary>Input</summary>

> ## Merge and layout assignment
>
> When a record is merged under a new parent, `MergeService` updates `parent_id` but never `pipeline_id`. The layout check in `parent_pipeline_matches` never fires for a merged record, so it keeps its old layout.
>
> The real fix is in `MergeService#process!`: when a child moves under a new parent, it should update `pipeline_id` along with `parent_id`. This is shared code used by every account, so changing it means checking the merge flow for all of them.
>
> Existing bad data can be backfilled from the audit log. `MergeService` writes these changes with `source: "merge"`, so the affected rows are `Change.where(field: "pipeline_id", source: "merge")`. On the QA database that is 123 past merges and 6 rows currently wrong.
>
> Until the shared fix lands, a per-account handler picks up a record that was just re-parented and assigns the correct layout. This is a workaround and can be removed once the merge behavior is fixed and the data is backfilled.

</details>

The skill did not fire #26. Its note: "this is a standalone engineering note, not a reply, so the full explanation is appropriate." It kept the diagnosis, the query, and the counts, and changed only sentence-level tells (#3 "The real fix is in", #11 passive voice).

### Package checks

`python3 scripts/validate-package.py` passes. `SKILL.md` is 392 lines.
